### PR TITLE
Add Reddit integration with mentions poller

### DIFF
--- a/packages/capabilities/README.md
+++ b/packages/capabilities/README.md
@@ -2,6 +2,33 @@
 
 The core AI orchestration service for Coach Artie 2.
 
+## Reddit Integration
+
+Enable the Reddit capability to read and write in a controlled set of subreddits.
+
+Environment variables:
+
+- `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`: Script app credentials from Reddit.
+- `REDDIT_USERNAME`, `REDDIT_PASSWORD`: Bot/account to post as (script app auth).
+- `REDDIT_ALLOWED_SUBS`: Optional comma-separated allowlist (e.g. `coachartie,funny`); if unset, all subs are allowed.
+- `REDDIT_USER_AGENT`: Optional user-agent override; defaults to `CoachArtieBot/1.0 (by /u/coachartie)`.
+- `REDDIT_SCOPES`: Optional space/comma separated scopes; defaults to `identity read submit privatemessages` (required for reading inbox/mentions, posting, and marking as read).
+
+Examples:
+
+```xml
+<capability name="reddit" action="status" />
+<capability name="reddit" action="list-subreddits" />
+<capability name="reddit" action="read" subreddit="coachartie" sort="new" limit="5" />
+<capability name="reddit" action="post" subreddit="coachartie" title="Weekly update" text="What shipped..." />
+<capability name="reddit" action="comment" thing_id="t3_abc123" text="Appreciate the feedback!" />
+<capability name="reddit" action="mentions" limit="10" />
+```
+
+Mention listener:
+- A scheduler job polls Reddit mentions hourly (`reddit-mentions`) and respects `REDDIT_ALLOWED_SUBS`.
+- Mentions are queued for processing with `shouldRespond=false` to avoid noisy status updates; Artie can still act using the reddit capability (e.g., comment back).
+
 ## MCP Tool Syntax
 
 **CRITICAL**: When calling MCP tools, use ONLY this syntax:

--- a/packages/capabilities/src/capabilities/communication/reddit.ts
+++ b/packages/capabilities/src/capabilities/communication/reddit.ts
@@ -1,0 +1,154 @@
+import { logger } from '@coachartie/shared';
+import { RegisteredCapability } from '../../services/capability/capability-registry.js';
+import { redditClient } from '../../services/reddit-client.js';
+
+export const redditCapability: RegisteredCapability = {
+  name: 'reddit',
+  emoji: '👽',
+  description:
+    'Read and write to Reddit using the configured account. Supports allowlisted subreddits to keep activity scoped while expanding later.',
+  supportedActions: ['status', 'list-subreddits', 'read', 'search', 'post', 'comment', 'mentions'],
+  examples: [
+    '<capability name="reddit" action="status" />',
+    '<capability name="reddit" action="read" subreddit="coachartie" limit="5" sort="new" />',
+    '<capability name="reddit" action="search" subreddit="coachartie" query="deployment" limit="3" />',
+    '<capability name="reddit" action="post" subreddit="coachartie" title="Weekly update" text="Here is what shipped..." />',
+    '<capability name="reddit" action="comment" thing_id="t3_abcd123" text="Thanks for the feedback!" />',
+    '<capability name="reddit" action="mentions" limit="10" />',
+  ],
+
+  handler: async (params, content) => {
+    const action = params.action || 'read';
+
+    if (action === 'status') {
+      return JSON.stringify({
+        configured: redditClient.isConfigured(),
+        missingEnv: redditClient.getMissingConfig(),
+        ...redditClient.getAllowedSubreddits(),
+      });
+    }
+
+    if (action === 'list-subreddits') {
+      const allowlist = redditClient.getAllowedSubreddits();
+        return JSON.stringify({
+          success: true,
+          mode: allowlist.mode,
+          allowedSubreddits: allowlist.allowedSubreddits,
+          note: allowlist.mode === 'open' ? 'Allowlist not set; all subreddits permitted.' : undefined,
+      });
+    }
+
+    if (!redditClient.isConfigured()) {
+      const missing = redditClient.getMissingConfig();
+      throw new Error(
+        `Reddit integration is not configured. Missing environment variables: ${missing.join(', ')}`
+      );
+    }
+
+    switch (action) {
+      case 'read': {
+        const subreddit = params.subreddit || params.sub;
+        const sort = params.sort || 'hot';
+        const limit = params.limit;
+        const time = params.time || params.t;
+
+        const result = await redditClient.fetchSubredditPosts({
+          subreddit,
+          sort,
+          limit,
+          time,
+        });
+
+        return JSON.stringify(result);
+      }
+
+      case 'search': {
+        const subreddit = params.subreddit || params.sub;
+        const query = params.query || params.q || content;
+        const limit = params.limit;
+
+        if (!query) {
+          throw new Error('Missing search query for Reddit search.');
+        }
+
+        const result = await redditClient.searchSubreddit({
+          subreddit,
+          query,
+          limit,
+        });
+
+        return JSON.stringify(result);
+      }
+
+      case 'post': {
+        const subreddit = params.subreddit || params.sub;
+        const title = params.title;
+        const text = content || params.text || params.body;
+        const url = params.url;
+        const flairId = params.flair_id || params.flairId;
+
+        if (!title) {
+          throw new Error('Title is required for Reddit posts.');
+        }
+
+        if (!text && !url) {
+          throw new Error('Provide text content or a URL when posting to Reddit.');
+        }
+
+        const result = await redditClient.submitPost({
+          subreddit,
+          title,
+          text,
+          url,
+          flairId,
+        });
+
+        return JSON.stringify(result);
+      }
+
+      case 'comment': {
+        const text = content || params.text || params.body || params.comment;
+        const thingId = params.thing_id || params.thingId;
+        const postId = params.post_id || params.postId || params.id;
+        const permalink = params.permalink || params.url;
+
+        if (!text) {
+          throw new Error('Comment text is required.');
+        }
+
+        const result = await redditClient.addComment({
+          thingId,
+          postId,
+          permalink,
+          text,
+        });
+
+        return JSON.stringify(result);
+      }
+
+      case 'mentions': {
+        const limit = params.limit;
+        const allowlist = redditClient.getAllowedSubreddits();
+        const result = await redditClient.fetchMentions(limit);
+
+        const filtered = allowlist.allowedSubreddits.length
+          ? result.mentions.filter((m) =>
+              m.subreddit ? allowlist.allowedSubreddits.includes(m.subreddit.toLowerCase()) : true
+            )
+          : result.mentions;
+
+        return JSON.stringify({
+          ...result,
+          mentions: filtered,
+          filteredOut: result.mentions.length - filtered.length,
+        });
+      }
+
+      default:
+        logger.warn(`Unknown reddit action: ${action}`);
+        throw new Error(
+          'Unknown reddit action. Supported actions: status, list-subreddits, read, search, post, comment'
+        );
+    }
+  },
+};

--- a/packages/capabilities/src/queues/consumer.ts
+++ b/packages/capabilities/src/queues/consumer.ts
@@ -223,7 +223,7 @@ export async function startMessageConsumer(): Promise<Worker<IncomingMessage, vo
   return worker;
 }
 
-function getOutgoingQueueName(type: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'irc'): string {
+function getOutgoingQueueName(type: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'irc' | 'reddit'): string {
   switch (type) {
     case 'discord':
       return QUEUES.OUTGOING_DISCORD;
@@ -235,6 +235,8 @@ function getOutgoingQueueName(type: 'discord' | 'slack' | 'sms' | 'email' | 'api
       return QUEUES.OUTGOING_EMAIL;
     case 'irc':
       return QUEUES.OUTGOING_IRC;
+    case 'reddit':
+      return QUEUES.OUTGOING_REDDIT;
     default:
       throw new Error(`Unknown response type: ${type}`);
   }

--- a/packages/capabilities/src/services/capability/capability-bootstrap.ts
+++ b/packages/capabilities/src/services/capability/capability-bootstrap.ts
@@ -48,6 +48,7 @@ import { slackUICapability } from '../../capabilities/slack/slack-ui.js';
 import { askQuestionCapability } from '../../capabilities/communication/ask-question.js';
 import { mentionProxyCapability } from '../../capabilities/communication/mention-proxy.js';
 import { emailCapability } from '../../capabilities/communication/email.js';
+import { redditCapability } from '../../capabilities/communication/reddit.js';
 // Analytics capabilities
 import { selfStatsCapability } from '../../capabilities/self-stats.js';
 // Services
@@ -248,6 +249,11 @@ export class CapabilityBootstrap {
       logger.info('📦 Registering quiz-game (multiplayer quizzes)...');
       capabilityRegistry.register(quizGameCapability);
       logger.info('✅ quiz-game registered successfully');
+
+      // Register reddit capability - read/write to Reddit
+      logger.info('📦 Registering reddit...');
+      capabilityRegistry.register(redditCapability);
+      logger.info('✅ reddit registered successfully');
 
       const totalCaps = capabilityRegistry.list().length;
       logger.info(

--- a/packages/capabilities/src/services/reddit-client.ts
+++ b/packages/capabilities/src/services/reddit-client.ts
@@ -1,0 +1,485 @@
+import axios, { AxiosInstance } from 'axios';
+import { logger } from '@coachartie/shared';
+
+const REDDIT_OAUTH_URL = 'https://www.reddit.com/api/v1/access_token';
+const REDDIT_API_BASE = 'https://oauth.reddit.com';
+
+type RedditSort = 'hot' | 'new' | 'top' | 'rising';
+type RedditTime = 'hour' | 'day' | 'week' | 'month' | 'year' | 'all';
+
+export interface RedditPostSummary {
+  id: string;
+  title: string;
+  author: string;
+  score: number;
+  comments: number;
+  createdUtc: number;
+  permalink: string;
+  url?: string;
+  selftext?: string;
+}
+
+export interface RedditReadOptions {
+  subreddit: string;
+  sort?: RedditSort;
+  time?: RedditTime;
+  limit?: number;
+}
+
+export interface RedditSearchOptions extends RedditReadOptions {
+  query: string;
+}
+
+export interface RedditSubmitOptions {
+  subreddit: string;
+  title: string;
+  text?: string;
+  url?: string;
+  flairId?: string;
+}
+
+export interface RedditCommentOptions {
+  thingId?: string;
+  postId?: string;
+  permalink?: string;
+  text: string;
+}
+
+export interface RedditMention {
+  name: string;
+  author: string;
+  subreddit?: string;
+  body?: string;
+  context?: string;
+  createdUtc?: number;
+  linkTitle?: string;
+  linkPermalink?: string;
+  isNew: boolean;
+}
+
+function parseAllowedSubreddits(raw?: string | null): string[] {
+  if (!raw) return [];
+
+  return raw
+    .split(',')
+    .map((s) => s.trim().replace(/^r\//i, '').toLowerCase())
+    .filter(Boolean);
+}
+
+export class RedditClient {
+  private accessToken?: string;
+  private tokenExpiresAt?: number;
+  private httpClient?: AxiosInstance;
+
+  private get config() {
+    return {
+      clientId: process.env.REDDIT_CLIENT_ID,
+      clientSecret: process.env.REDDIT_CLIENT_SECRET,
+      username: process.env.REDDIT_USERNAME,
+      password: process.env.REDDIT_PASSWORD,
+      userAgent: process.env.REDDIT_USER_AGENT || 'CoachArtieBot/1.0 (by /u/coachartie)',
+      allowedSubreddits: parseAllowedSubreddits(process.env.REDDIT_ALLOWED_SUBS),
+    };
+  }
+
+  private get scopes(): string {
+    const raw = process.env.REDDIT_SCOPES;
+    if (raw) {
+      return raw
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join(' ');
+    }
+
+    // Default scopes cover identity + read inbox + submit + mark read (privatemessages) per Reddit docs
+    return 'identity read submit privatemessages';
+  }
+
+  isConfigured(): boolean {
+    const { clientId, clientSecret, username, password } = this.config;
+    return Boolean(clientId && clientSecret && username && password);
+  }
+
+  getMissingConfig(): string[] {
+    const missing = [];
+    const { clientId, clientSecret, username, password } = this.config;
+    if (!clientId) missing.push('REDDIT_CLIENT_ID');
+    if (!clientSecret) missing.push('REDDIT_CLIENT_SECRET');
+    if (!username) missing.push('REDDIT_USERNAME');
+    if (!password) missing.push('REDDIT_PASSWORD');
+    return missing;
+  }
+
+  getAllowedSubreddits() {
+    const allowed = this.config.allowedSubreddits;
+    return {
+      mode: allowed.length > 0 ? 'allowlist' : 'open',
+      allowedSubreddits: allowed,
+    };
+  }
+
+  getBotUsername(): string | undefined {
+    return this.config.username;
+  }
+
+  private normalizeSubreddit(subreddit?: string): string {
+    if (!subreddit) return '';
+    return subreddit.replace(/^r\//i, '').toLowerCase();
+  }
+
+  private ensureSubredditAllowed(subreddit?: string): string {
+    const normalized = this.normalizeSubreddit(subreddit);
+    const { allowedSubreddits } = this.config;
+
+    if (!normalized) {
+      throw new Error('Subreddit is required (e.g. subreddit="coachartie")');
+    }
+
+    if (allowedSubreddits.length > 0 && !allowedSubreddits.includes(normalized)) {
+      throw new Error(
+        `Subreddit r/${normalized} is not in the allowlist. Allowed: ${allowedSubreddits.join(', ')}`
+      );
+    }
+
+    return normalized;
+  }
+
+  private async ensureHttpClient(): Promise<AxiosInstance> {
+    if (this.httpClient && this.tokenExpiresAt && Date.now() < this.tokenExpiresAt) {
+      return this.httpClient;
+    }
+
+    const token = await this.fetchAccessToken();
+    this.tokenExpiresAt = Date.now() + (token.expiresIn - 60) * 1000;
+
+    this.httpClient = axios.create({
+      baseURL: REDDIT_API_BASE,
+      headers: {
+        Authorization: `Bearer ${token.accessToken}`,
+        'User-Agent': this.config.userAgent,
+      },
+    });
+
+    return this.httpClient;
+  }
+
+  private async fetchAccessToken(): Promise<{ accessToken: string; expiresIn: number }> {
+    if (!this.isConfigured()) {
+      const missing = this.getMissingConfig();
+      throw new Error(`Reddit credentials missing: ${missing.join(', ')}`);
+    }
+
+    const { clientId, clientSecret, username, password, userAgent } = this.config;
+    const body = new URLSearchParams({
+      grant_type: 'password',
+      username: username as string,
+      password: password as string,
+      scope: this.scopes,
+    });
+
+    try {
+      const response = await axios.post(REDDIT_OAUTH_URL, body, {
+        auth: {
+          username: clientId as string,
+          password: clientSecret as string,
+        },
+        headers: {
+          'User-Agent': userAgent,
+        },
+      });
+
+      const accessToken = response.data.access_token as string;
+      const expiresIn = response.data.expires_in as number;
+
+      if (!accessToken) {
+        throw new Error('Missing access_token in Reddit response');
+      }
+
+      logger.info('✅ Obtained Reddit access token');
+      this.accessToken = accessToken;
+
+      return { accessToken, expiresIn: expiresIn || 3600 };
+    } catch (error) {
+      logger.error('❌ Failed to obtain Reddit token:', error);
+      throw new Error('Reddit authentication failed. Check credentials and scopes.');
+    }
+  }
+
+  async fetchSubredditPosts(options: RedditReadOptions): Promise<{
+    success: boolean;
+    subreddit: string;
+    posts: RedditPostSummary[];
+  }> {
+    const subreddit = this.ensureSubredditAllowed(options.subreddit);
+    const sort: RedditSort = (options.sort as RedditSort) || 'hot';
+    const limit = Math.min(Math.max(Number(options.limit) || 10, 1), 50);
+    const time: RedditTime | undefined = options.time as RedditTime;
+
+    const client = await this.ensureHttpClient();
+    const params: Record<string, string | number> = { limit };
+    if (sort === 'top' && time) {
+      params.t = time;
+    }
+
+    try {
+      const response = await client.get(`/r/${subreddit}/${sort}.json`, { params });
+      const posts: RedditPostSummary[] =
+        response.data?.data?.children?.map((child: any) => {
+          const data = child.data;
+          return {
+            id: data.id,
+            title: data.title,
+            author: data.author,
+            score: data.score,
+            comments: data.num_comments,
+            createdUtc: data.created_utc,
+            permalink: `https://reddit.com${data.permalink}`,
+            url: data.url,
+            selftext: data.selftext,
+          } as RedditPostSummary;
+        }) || [];
+
+      return { success: true, subreddit, posts };
+    } catch (error) {
+      logger.error(`❌ Failed to fetch posts for r/${subreddit}:`, error);
+      throw new Error(`Unable to fetch posts for r/${subreddit}.`);
+    }
+  }
+
+  async searchSubreddit(options: RedditSearchOptions): Promise<{
+    success: boolean;
+    subreddit: string;
+    query: string;
+    posts: RedditPostSummary[];
+  }> {
+    const subreddit = this.ensureSubredditAllowed(options.subreddit);
+    const query = options.query;
+    if (!query) {
+      throw new Error('Search query is required.');
+    }
+
+    const limit = Math.min(Math.max(Number(options.limit) || 10, 1), 50);
+    const client = await this.ensureHttpClient();
+
+    try {
+      const response = await client.get(`/r/${subreddit}/search.json`, {
+        params: {
+          q: query,
+          restrict_sr: 1,
+          limit,
+        },
+      });
+
+      const posts: RedditPostSummary[] =
+        response.data?.data?.children?.map((child: any) => {
+          const data = child.data;
+          return {
+            id: data.id,
+            title: data.title,
+            author: data.author,
+            score: data.score,
+            comments: data.num_comments,
+            createdUtc: data.created_utc,
+            permalink: `https://reddit.com${data.permalink}`,
+            url: data.url,
+            selftext: data.selftext,
+          } as RedditPostSummary;
+        }) || [];
+
+      return { success: true, subreddit, query, posts };
+    } catch (error) {
+      logger.error(`❌ Reddit search failed for r/${subreddit}:`, error);
+      throw new Error(`Unable to search r/${subreddit} for "${query}".`);
+    }
+  }
+
+  async submitPost(options: RedditSubmitOptions): Promise<{
+    success: boolean;
+    subreddit: string;
+    id?: string;
+    url?: string;
+    permalink?: string;
+    message?: string;
+  }> {
+    const subreddit = this.ensureSubredditAllowed(options.subreddit);
+    if (!options.title) {
+      throw new Error('Title is required to submit a Reddit post.');
+    }
+
+    if (!options.text && !options.url) {
+      throw new Error('Provide either text content or a URL for the post.');
+    }
+
+    const client = await this.ensureHttpClient();
+    const kind = options.url ? 'link' : 'self';
+
+    try {
+      const response = await client.post(
+        '/api/submit',
+        new URLSearchParams({
+          sr: subreddit,
+          kind,
+          title: options.title,
+          text: options.text || '',
+          url: options.url || '',
+          flair_id: options.flairId || '',
+          api_type: 'json',
+        })
+      );
+
+      const json = response.data?.json;
+      const postId = json?.data?.id;
+      const permalink = json?.data?.url || (postId ? `https://reddit.com/comments/${postId}` : undefined);
+
+      if (json?.errors?.length) {
+        throw new Error(json.errors.map((e: any) => e.join(': ')).join('; '));
+      }
+
+      return {
+        success: true,
+        subreddit,
+        id: postId,
+        url: options.url,
+        permalink,
+        message: 'Post submitted to Reddit',
+      };
+    } catch (error) {
+      logger.error(`❌ Failed to submit post to r/${subreddit}:`, error);
+      throw new Error(`Unable to submit post to r/${subreddit}.`);
+    }
+  }
+
+  async addComment(options: RedditCommentOptions): Promise<{
+    success: boolean;
+    thingId?: string;
+    permalink?: string;
+    message?: string;
+  }> {
+    const text = options.text;
+    if (!text) {
+      throw new Error('Comment text is required.');
+    }
+
+    const thingId = await this.resolveThingId(options);
+    const client = await this.ensureHttpClient();
+
+    try {
+      const response = await client.post(
+        '/api/comment',
+        new URLSearchParams({
+          thing_id: thingId,
+          text,
+          api_type: 'json',
+        })
+      );
+
+      const data = response.data?.json?.data;
+      if (response.data?.json?.errors?.length) {
+        throw new Error(response.data.json.errors.map((e: any) => e.join(': ')).join('; '));
+      }
+
+      return {
+        success: true,
+        thingId,
+        permalink: data?.things?.[0]?.data?.permalink
+          ? `https://reddit.com${data.things[0].data.permalink}`
+          : undefined,
+        message: 'Comment posted to Reddit',
+      };
+    } catch (error) {
+      logger.error('❌ Failed to post Reddit comment:', error);
+      throw new Error('Unable to post comment. Check thing_id or Reddit status.');
+    }
+  }
+
+  private async resolveThingId(options: RedditCommentOptions): Promise<string> {
+    if (options.thingId) {
+      return this.normalizeThingId(options.thingId);
+    }
+
+    if (options.postId) {
+      return this.normalizeThingId(options.postId, 't3');
+    }
+
+    if (options.permalink) {
+      const client = await this.ensureHttpClient();
+      try {
+        const response = await client.get(`${options.permalink.replace(/^https?:\/\/[^/]+/, '')}.json`);
+        const postId = response.data?.[0]?.data?.children?.[0]?.data?.id;
+        if (!postId) throw new Error('Unable to resolve permalink to a Reddit thing id');
+        return this.normalizeThingId(postId, 't3');
+      } catch (error) {
+        logger.error('❌ Failed to resolve permalink to thing_id:', error);
+        throw new Error('Could not resolve permalink to a Reddit post/comment id.');
+      }
+    }
+
+    throw new Error('Provide a thing_id, post_id, or permalink to comment on.');
+  }
+
+  private normalizeThingId(id: string, prefix: 't1' | 't3' = 't3'): string {
+    if (id.startsWith('t1_') || id.startsWith('t3_')) {
+      return id;
+    }
+    return `${prefix}_${id}`;
+  }
+
+  async fetchMentions(limit = 50): Promise<{
+    success: boolean;
+    mentions: RedditMention[];
+  }> {
+    const client = await this.ensureHttpClient();
+    const safeLimit = Math.min(Math.max(Number(limit) || 25, 1), 100);
+
+    try {
+      const response = await client.get('/message/unread.json', {
+        params: {
+          limit: safeLimit,
+          mark: false, // do not auto-mark as read; we will mark after queueing
+        },
+      });
+
+      const children = response.data?.data?.children || [];
+      const mentions: RedditMention[] = children
+        .map((child: any) => child?.data)
+        .filter((data: any) => data?.type === 'username_mention')
+        .map((data: any) => ({
+          name: data.name,
+          author: data.author,
+          subreddit: data.subreddit,
+          body: data.body,
+          context: data.context,
+          createdUtc: data.created_utc,
+          linkTitle: data.link_title,
+          linkPermalink: data.link_permalink,
+          isNew: !!data.new,
+        }));
+
+      return { success: true, mentions };
+    } catch (error) {
+      logger.error('❌ Failed to fetch Reddit mentions:', error);
+      throw new Error('Unable to fetch Reddit mentions (inbox).');
+    }
+  }
+
+  async markMessagesRead(fullnames: string[]): Promise<void> {
+    if (!fullnames.length) return;
+    const client = await this.ensureHttpClient();
+
+    try {
+      await client.post(
+        '/api/read_message',
+        new URLSearchParams({
+          id: fullnames.join(','),
+        })
+      );
+      logger.info(`✅ Marked ${fullnames.length} Reddit mention(s) as read`);
+    } catch (error) {
+      logger.error('❌ Failed to mark Reddit messages as read:', error);
+      // Do not throw to avoid blocking processing; warn only
+    }
+  }
+}
+
+export const redditClient = new RedditClient();

--- a/packages/capabilities/src/services/reddit-mention-monitor.ts
+++ b/packages/capabilities/src/services/reddit-mention-monitor.ts
@@ -1,0 +1,120 @@
+import { v4 as uuidv4 } from 'uuid';
+import { createRedisConnection, QUEUES, logger } from '@coachartie/shared';
+import { Queue } from 'bullmq';
+import { redditClient } from './reddit-client.js';
+
+interface MentionJobContext {
+  mentionId: string;
+  mention: {
+    name: string;
+    author: string;
+    subreddit?: string;
+    body?: string;
+    context?: string;
+    linkTitle?: string;
+    linkPermalink?: string;
+    createdUtc?: number;
+  };
+}
+
+export class RedditMentionMonitor {
+  private incomingQueue: Queue | null = null;
+
+  constructor() {
+    // Lazy init; create queue only if Redis is available
+  }
+
+  private async ensureQueue(): Promise<Queue> {
+    if (this.incomingQueue) return this.incomingQueue;
+    this.incomingQueue = new Queue(QUEUES.INCOMING_MESSAGES, {
+      connection: createRedisConnection(),
+    });
+    return this.incomingQueue;
+  }
+
+  async pollMentions(): Promise<{ fetched: number; queued: number; skipped: number }> {
+    if (!redditClient.isConfigured()) {
+      logger.warn('Reddit mention poll skipped: reddit not configured');
+      return { fetched: 0, queued: 0, skipped: 0 };
+    }
+
+    const allowlist = redditClient.getAllowedSubreddits();
+
+    const mentionsResult = await redditClient.fetchMentions(50);
+    const mentions = mentionsResult.mentions;
+
+    if (!mentions.length) {
+      logger.info('No new Reddit mentions found');
+      return { fetched: 0, queued: 0, skipped: 0 };
+    }
+
+    const allowedMentions = mentions.filter((m) => {
+      if (allowlist.allowedSubreddits.length === 0) return true;
+      return m.subreddit ? allowlist.allowedSubreddits.includes(m.subreddit.toLowerCase()) : false;
+    });
+
+    const skipped = mentions.length - allowedMentions.length;
+
+    // Queue messages for processing
+    const queue = await this.ensureQueue();
+    for (const mention of allowedMentions) {
+      const mentionId = mention.name || uuidv4();
+      const messageText = [
+        `Reddit mention for bot account`,
+        `Author: u/${mention.author}`,
+        mention.subreddit ? `Subreddit: r/${mention.subreddit}` : null,
+        mention.linkTitle ? `Thread: ${mention.linkTitle}` : null,
+        mention.context ? `Context: https://reddit.com${mention.context}` : mention.linkPermalink,
+        mention.body ? `Quoted: ${mention.body}` : null,
+      ]
+        .filter(Boolean)
+        .join('\n');
+
+      const context: MentionJobContext = {
+        mentionId,
+        mention: {
+          name: mention.name,
+          author: mention.author,
+          subreddit: mention.subreddit,
+          body: mention.body,
+          context: mention.context,
+          linkTitle: mention.linkTitle,
+          linkPermalink: mention.linkPermalink,
+          createdUtc: mention.createdUtc,
+        },
+      };
+
+      await queue.add('incoming-message', {
+        id: mentionId,
+        timestamp: new Date(),
+        retryCount: 0,
+        source: 'reddit',
+        userId: `reddit:${mention.author}`,
+        message: messageText,
+        context: {
+          platform: 'reddit',
+          shouldRespond: false, // avoid noisy status replies; LLM can still act with capabilities
+          reddit: {
+            ...context,
+            allowedSubreddits: allowlist.allowedSubreddits,
+            botUsername: redditClient.getBotUsername(),
+          },
+        },
+        respondTo: {
+          type: 'reddit',
+        },
+      });
+    }
+
+    // Mark all mentions as read (both allowed and skipped) to avoid reprocessing noise
+    await redditClient.markMessagesRead(mentions.map((m) => m.name).filter(Boolean));
+
+    logger.info(
+      `Queued ${allowedMentions.length} Reddit mention(s); skipped ${skipped} (not in allowlist)`
+    );
+
+    return { fetched: mentions.length, queued: allowedMentions.length, skipped };
+  }
+}
+
+export const redditMentionMonitor = new RedditMentionMonitor();

--- a/packages/shared/src/constants/queues.ts
+++ b/packages/shared/src/constants/queues.ts
@@ -6,6 +6,7 @@ export const QUEUES = {
   OUTGOING_SMS: 'coachartie-sms-outgoing',
   OUTGOING_EMAIL: 'coachartie-email-outgoing',
   OUTGOING_IRC: 'coachartie-irc-outgoing',
+  OUTGOING_REDDIT: 'coachartie-reddit-outgoing',
   DEAD_LETTER: 'coachartie-dlq',
 } as const;
 

--- a/packages/shared/src/types/queue.ts
+++ b/packages/shared/src/types/queue.ts
@@ -2,7 +2,7 @@ export interface BaseQueueMessage {
   id: string;
   timestamp: Date;
   retryCount: number;
-  source: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'capabilities' | 'irc';
+  source: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'capabilities' | 'irc' | 'reddit';
 }
 
 export interface IncomingMessage extends BaseQueueMessage {
@@ -10,7 +10,7 @@ export interface IncomingMessage extends BaseQueueMessage {
   message: string;
   context?: Record<string, any>;
   respondTo: {
-    type: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'irc';
+    type: 'discord' | 'slack' | 'sms' | 'email' | 'api' | 'irc' | 'reddit';
     channelId?: string;
     phoneNumber?: string;
     emailAddress?: string;


### PR DESCRIPTION
## Summary
Rebased and fixed version of #72.

- Add reddit capability (read/search/post/comment/mentions) with subreddit allowlist
- Add Reddit client using script-app auth with mention fetch + mark-read
- Add mention monitor service with hourly scheduler job
- Update queue types to include reddit source/destination

## Config
- Required: REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_USERNAME, REDDIT_PASSWORD
- Optional: REDDIT_ALLOWED_SUBS (comma-separated allowlist)

## Test plan
- [x] Build passes
- [x] Existing tests pass (90/98 - same as main)

Closes #72

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)