### PR TITLE
feat(quiz): streak competition + optional LLM judge for fuzzy answers

### DIFF
--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -10,14 +10,17 @@ import { buildLiveQuizMessage, buildQuizSummary } from '../services/quiz-embed.j
 import {
   ensureDailyQuizTables,
   getOrCreateDailyPuzzle,
+  getServerLeaderboard,
   getUserPlay,
   startUserPlay,
   todayKey,
   DAILY_QUESTION_COUNT,
+  type LeaderboardScope,
 } from '../services/daily-quiz.js';
 import {
   buildDailyGameMessage,
   buildDailyResultMessage,
+  buildLeaderboardMessage,
 } from '../services/daily-quiz-embed.js';
 
 export const quizCommand = {
@@ -84,6 +87,22 @@ export const quizCommand = {
               { name: 'Search & Rescue', value: 'SAR_AND_WILDERNESS' }
             )
         )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('leaderboard')
+        .setDescription("This server's daily-quiz leaderboard")
+        .addStringOption((option) =>
+          option
+            .setName('scope')
+            .setDescription('Time range (default: all-time)')
+            .setRequired(false)
+            .addChoices(
+              { name: "Today's Daily", value: 'today' },
+              { name: 'This Week', value: 'week' },
+              { name: 'All-Time', value: 'alltime' }
+            )
+        )
     ),
 
   async execute(
@@ -103,6 +122,8 @@ export const quizCommand = {
           return await handleSkip(interaction);
         case 'daily':
           return await handleDaily(interaction);
+        case 'leaderboard':
+          return await handleLeaderboard(interaction);
         default:
           return await interaction.reply({
             content: 'Unknown subcommand',
@@ -334,7 +355,13 @@ async function handleDaily(
 
   let play = getUserPlay(interaction.user.id, date, deck);
   if (!play) {
-    play = startUserPlay(interaction.user.id, interaction.user.username, date, deck);
+    play = startUserPlay(
+      interaction.user.id,
+      interaction.user.username,
+      date,
+      deck,
+      interaction.guildId
+    );
   }
 
   if (play.completed) {
@@ -350,4 +377,25 @@ async function handleDaily(
   const payload = buildDailyGameMessage(play, puzzle);
   await interaction.editReply(payload);
   return undefined;
+}
+
+/**
+ * Public server leaderboard for the daily quiz.
+ */
+async function handleLeaderboard(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  if (!interaction.guildId) {
+    return await interaction.reply({
+      content: '⚠️ Run this in a server channel — DMs don\'t have a leaderboard.',
+      ephemeral: true,
+    });
+  }
+
+  const scopeOption = (interaction.options.getString('scope') as LeaderboardScope) || 'alltime';
+  ensureDailyQuizTables();
+  const rows = getServerLeaderboard(interaction.guildId, scopeOption);
+  const guildName = interaction.guild?.name || 'This server';
+  const payload = buildLeaderboardMessage(rows, scopeOption, guildName);
+  return await interaction.reply(payload);
 }

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -46,6 +46,12 @@ export const quizCommand = {
             .setMinValue(1)
             .setMaxValue(50)
         )
+        .addBooleanOption((option) =>
+          option
+            .setName('ai_judge')
+            .setDescription('Use a light LLM to accept fuzzy/equivalent answers (default: off)')
+            .setRequired(false)
+        )
     )
     .addSubcommand((subcommand) =>
       subcommand.setName('stop').setDescription('End the current quiz')
@@ -96,9 +102,11 @@ async function handleStart(
 ): Promise<InteractionResponse<boolean> | undefined> {
   const deckOption = interaction.options.getString('deck');
   const questionsOption = interaction.options.getInteger('questions');
+  const aiJudgeOption = interaction.options.getBoolean('ai_judge');
 
   const deckId = deckOption === 'all' ? undefined : deckOption || undefined;
   const questionCount = questionsOption || 10;
+  const aiJudge = aiJudgeOption ?? false;
 
   // Check if quiz already active
   if (quizSessionManager.hasActiveQuiz(interaction.channelId)) {
@@ -117,6 +125,7 @@ async function handleStart(
       userId: interaction.user.id,
       deckId,
       questionCount,
+      aiJudge,
       onTimeout: async (timedOutSession: QuizSession) => {
         // Handle timeout - reveal answer and move to next question
         try {
@@ -125,7 +134,7 @@ async function handleStart(
           );
 
           let response = `⏰ **Time's up!**\nThe answer was: **${answer}**\n`;
-          response += `📊 ${quizSessionManager.formatScores(timedOutSession.scores)}\n`;
+          response += `📊 ${quizSessionManager.formatScores(timedOutSession.scores, undefined, timedOutSession.streaks)}\n`;
 
           if (nextSession && nextSession.currentCard) {
             response += `\n---\n\n`;
@@ -161,11 +170,15 @@ async function handleStart(
 
     const deckDisplay = session.deckId || 'All Decks';
 
+    const judgeLine = session.aiJudge
+      ? '\n**AI Judge:** on — fuzzy/equivalent answers accepted'
+      : '';
+
     const embed = new EmbedBuilder()
       .setColor(0x00ff00)
       .setTitle('🎮 Quiz Started!')
       .setDescription(
-        `**Deck:** ${deckDisplay}\n**Questions:** ${session.totalQuestions}\n\nType your answers in chat - first correct answer wins!`
+        `**Deck:** ${deckDisplay}\n**Questions:** ${session.totalQuestions}${judgeLine}\n\nType your answers in chat — first correct answer wins, build a 🔥 streak for bragging rights!`
       )
       .setFooter({ text: `Started by ${interaction.user.username}` })
       .setTimestamp();
@@ -206,6 +219,9 @@ async function handleStop(
     });
   }
 
+  const sessionBefore = quizSessionManager.getSession(interaction.channelId);
+  const bestStreaks = sessionBefore ? new Map(sessionBefore.bestStreaks) : new Map<string, number>();
+
   const embed = new EmbedBuilder()
     .setColor(0xff9900)
     .setTitle('🛑 Quiz Stopped')
@@ -229,6 +245,15 @@ async function handleStop(
     }
   }
 
+  const streakLeaders = quizSessionManager.getStreakLeaders(bestStreaks);
+  if (streakLeaders.length > 0) {
+    const top = streakLeaders.slice(0, 3);
+    embed.addFields({
+      name: '🔥 Streak Leaders',
+      value: top.map(([uid, streak]) => `<@${uid}>: ${streak} in a row`).join('\n'),
+    });
+  }
+
   return await interaction.reply({ embeds: [embed] });
 }
 
@@ -249,7 +274,7 @@ async function handleScores(
     .setTitle('📊 Quiz Scores')
     .setDescription(
       session.scores.size > 0
-        ? quizSessionManager.formatScores(session.scores)
+        ? quizSessionManager.formatScores(session.scores, undefined, session.streaks)
         : 'No scores yet - be the first to answer!'
     )
     .addFields(

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -3,25 +3,73 @@ import {
   ChatInputCommandInteraction,
   InteractionResponse,
   Channel,
+  PermissionsBitField,
 } from 'discord.js';
 import { logger } from '@coachartie/shared';
 import { quizSessionManager, QuizSession } from '../services/quiz-session-manager.js';
 import { buildLiveQuizMessage, buildQuizSummary } from '../services/quiz-embed.js';
 import {
   ensureDailyQuizTables,
+  fetchUniqueCards,
+  getGuildConfig,
   getOrCreateDailyPuzzle,
   getServerLeaderboard,
   getUserPlay,
+  isDeckAllowedForGuild,
+  KNOWN_DECKS,
+  setGuildAllowedDecks,
+  setGuildDefaultDeck,
   startUserPlay,
   todayKey,
+  tomorrowKey,
   DAILY_QUESTION_COUNT,
   type LeaderboardScope,
 } from '../services/daily-quiz.js';
 import {
   buildDailyGameMessage,
   buildDailyResultMessage,
+  buildGuildConfigEmbed,
   buildLeaderboardMessage,
+  buildScheduleDraftMessage,
 } from '../services/daily-quiz-embed.js';
+
+const DECK_CHOICES = [
+  { name: 'All Decks (Random)', value: 'all' },
+  { name: 'Computers', value: 'COMPUTERS' },
+  { name: 'Electrical & Radio', value: 'ELECTRICAL_AND_RADIO' },
+  { name: 'Politics', value: 'POLITICS' },
+  { name: "Rubik's 2x2", value: 'RUBIKS_2x2' },
+  { name: 'Search & Rescue', value: 'SAR_AND_WILDERNESS' },
+];
+
+const SCHEDULE_DRAFTS = new Map<string, import('../services/quiz-session-manager.js').FlashcardResponse[]>();
+const draftKey = (userId: string, guildId: string, date: string, deck: string) =>
+  `${userId}:${guildId}:${date}:${deck}`;
+export function getScheduleDraft(
+  userId: string,
+  guildId: string,
+  date: string,
+  deck: string
+): import('../services/quiz-session-manager.js').FlashcardResponse[] | undefined {
+  return SCHEDULE_DRAFTS.get(draftKey(userId, guildId, date, deck));
+}
+export function setScheduleDraft(
+  userId: string,
+  guildId: string,
+  date: string,
+  deck: string,
+  cards: import('../services/quiz-session-manager.js').FlashcardResponse[]
+): void {
+  SCHEDULE_DRAFTS.set(draftKey(userId, guildId, date, deck), cards);
+}
+export function clearScheduleDraft(
+  userId: string,
+  guildId: string,
+  date: string,
+  deck: string
+): void {
+  SCHEDULE_DRAFTS.delete(draftKey(userId, guildId, date, deck));
+}
 
 export const quizCommand = {
   data: new SlashCommandBuilder()
@@ -103,14 +151,61 @@ export const quizCommand = {
               { name: 'All-Time', value: 'alltime' }
             )
         )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('schedule')
+        .setDescription("(Admin) Hand-pick tomorrow's daily quiz cards for this server")
+        .addStringOption((option) =>
+          option
+            .setName('deck')
+            .setDescription('Deck to pull candidate cards from')
+            .setRequired(false)
+            .addChoices(...DECK_CHOICES)
+        )
+    )
+    .addSubcommandGroup((group) =>
+      group
+        .setName('config')
+        .setDescription('(Admin) Per-server quiz settings')
+        .addSubcommand((subcommand) =>
+          subcommand.setName('show').setDescription("Show this server's quiz config")
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('allow-decks')
+            .setDescription('Set the allow-list of decks (empty = all). Comma-separated.')
+            .addStringOption((option) =>
+              option
+                .setName('decks')
+                .setDescription('e.g. POLITICS,COMPUTERS — leave blank to allow all')
+                .setRequired(false)
+            )
+        )
+        .addSubcommand((subcommand) =>
+          subcommand
+            .setName('default-deck')
+            .setDescription('Set the default deck for /quiz daily (clears if omitted)')
+            .addStringOption((option) =>
+              option
+                .setName('deck')
+                .setDescription('Deck id')
+                .setRequired(false)
+                .addChoices(...DECK_CHOICES)
+            )
+        )
     ),
 
   async execute(
     interaction: ChatInputCommandInteraction
   ): Promise<InteractionResponse<boolean> | undefined> {
+    const group = interaction.options.getSubcommandGroup(false);
     const subcommand = interaction.options.getSubcommand();
 
     try {
+      if (group === 'config') {
+        return await handleConfig(interaction, subcommand);
+      }
       switch (subcommand) {
         case 'start':
           return await handleStart(interaction);
@@ -124,6 +219,8 @@ export const quizCommand = {
           return await handleDaily(interaction);
         case 'leaderboard':
           return await handleLeaderboard(interaction);
+        case 'schedule':
+          return await handleSchedule(interaction);
         default:
           return await interaction.reply({
             content: 'Unknown subcommand',
@@ -329,7 +426,23 @@ async function handleDaily(
   interaction: ChatInputCommandInteraction
 ): Promise<InteractionResponse<boolean> | undefined> {
   const deckOption = interaction.options.getString('deck');
-  const deck = deckOption && deckOption !== 'all' ? deckOption : '';
+  let deck: string;
+  if (deckOption === null && interaction.guildId) {
+    // No explicit pick → fall back to the guild's configured default.
+    const cfg = getGuildConfig(interaction.guildId);
+    deck = cfg.defaultDeck ?? '';
+  } else {
+    deck = deckOption && deckOption !== 'all' ? deckOption : '';
+  }
+
+  if (interaction.guildId && !isDeckAllowedForGuild(interaction.guildId, deck)) {
+    const cfg = getGuildConfig(interaction.guildId);
+    return await interaction.reply({
+      content: `❌ The **${deck || 'All Decks'}** deck isn't enabled on this server.\nAllowed: ${cfg.allowedDecks.map((d) => `\`${d || 'all'}\``).join(', ')}`,
+      ephemeral: true,
+    });
+  }
+
   const date = todayKey();
 
   await interaction.deferReply({ ephemeral: true });
@@ -337,7 +450,7 @@ async function handleDaily(
 
   let puzzle;
   try {
-    puzzle = await getOrCreateDailyPuzzle(date, deck);
+    puzzle = await getOrCreateDailyPuzzle(date, deck, interaction.guildId);
   } catch (e) {
     logger.error('Failed to fetch daily puzzle:', e);
     await interaction.editReply({
@@ -377,6 +490,118 @@ async function handleDaily(
   const payload = buildDailyGameMessage(play, puzzle);
   await interaction.editReply(payload);
   return undefined;
+}
+
+function ensureAdmin(interaction: ChatInputCommandInteraction): boolean {
+  if (!interaction.guildId) return false;
+  const perms = interaction.memberPermissions;
+  if (!perms) return false;
+  return perms.has(PermissionsBitField.Flags.ManageGuild);
+}
+
+/**
+ * Admin: pre-pick tomorrow's daily puzzle. Ephemeral preview with shuffle /
+ * use / cancel buttons.
+ */
+async function handleSchedule(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  if (!interaction.guildId) {
+    return await interaction.reply({
+      content: '⚠️ Run this in a server channel.',
+      ephemeral: true,
+    });
+  }
+  if (!ensureAdmin(interaction)) {
+    return await interaction.reply({
+      content: '🚫 Need **Manage Server** permission to schedule daily quizzes.',
+      ephemeral: true,
+    });
+  }
+
+  const deckOption = interaction.options.getString('deck');
+  const deck = deckOption && deckOption !== 'all' ? deckOption : '';
+  const date = tomorrowKey();
+
+  if (!isDeckAllowedForGuild(interaction.guildId, deck)) {
+    return await interaction.reply({
+      content: `❌ That deck isn't in this server's allow-list. See \`/quiz config show\`.`,
+      ephemeral: true,
+    });
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+  ensureDailyQuizTables();
+
+  let cards: import('../services/quiz-session-manager.js').FlashcardResponse[] = [];
+  try {
+    cards = await fetchUniqueCards(deck, DAILY_QUESTION_COUNT);
+  } catch (e) {
+    logger.error('Schedule preview fetch failed:', e);
+  }
+
+  setScheduleDraft(interaction.user.id, interaction.guildId, date, deck, cards);
+  const payload = buildScheduleDraftMessage(date, deck, cards);
+  await interaction.editReply(payload);
+  return undefined;
+}
+
+/**
+ * Admin: per-server quiz config (allow-list, default deck).
+ */
+async function handleConfig(
+  interaction: ChatInputCommandInteraction,
+  subcommand: string
+): Promise<InteractionResponse<boolean> | undefined> {
+  if (!interaction.guildId) {
+    return await interaction.reply({
+      content: '⚠️ Run this in a server channel.',
+      ephemeral: true,
+    });
+  }
+
+  if (subcommand !== 'show' && !ensureAdmin(interaction)) {
+    return await interaction.reply({
+      content: '🚫 Need **Manage Server** permission to change quiz config.',
+      ephemeral: true,
+    });
+  }
+
+  ensureDailyQuizTables();
+  const guildName = interaction.guild?.name || 'This server';
+
+  if (subcommand === 'show') {
+    const cfg = getGuildConfig(interaction.guildId);
+    return await interaction.reply({ ...buildGuildConfigEmbed(cfg, guildName), ephemeral: true });
+  }
+
+  if (subcommand === 'allow-decks') {
+    const raw = interaction.options.getString('decks') || '';
+    // Parse comma-separated deck IDs; "all" is the empty-deck sentinel.
+    const tokens = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => (s.toLowerCase() === 'all' ? '' : s.toUpperCase()));
+    const unknown = tokens.filter((t) => !KNOWN_DECKS.includes(t as any));
+    if (unknown.length > 0) {
+      return await interaction.reply({
+        content: `❌ Unknown deck(s): ${unknown.map((u) => `\`${u}\``).join(', ')}\nKnown: ${KNOWN_DECKS.map((d) => d || 'all').join(', ')}`,
+        ephemeral: true,
+      });
+    }
+    const cfg = setGuildAllowedDecks(interaction.guildId, tokens);
+    return await interaction.reply({ ...buildGuildConfigEmbed(cfg, guildName), ephemeral: true });
+  }
+
+  if (subcommand === 'default-deck') {
+    const deckOption = interaction.options.getString('deck');
+    const deck = deckOption === null ? null : deckOption === 'all' ? '' : deckOption;
+    const cfg = setGuildDefaultDeck(interaction.guildId, deck);
+    return await interaction.reply({ ...buildGuildConfigEmbed(cfg, guildName), ephemeral: true });
+  }
+
+  return await interaction.reply({ content: 'Unknown config subcommand', ephemeral: true });
 }
 
 /**

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -11,12 +11,16 @@ import { buildLiveQuizMessage, buildQuizSummary } from '../services/quiz-embed.j
 import {
   ensureDailyQuizTables,
   fetchUniqueCards,
+  getDeckPoll,
+  getDeckVoteTallies,
   getGuildConfig,
   getOrCreateDailyPuzzle,
+  getOrCreateDeckPoll,
   getServerLeaderboard,
   getUserPlay,
   isDeckAllowedForGuild,
   KNOWN_DECKS,
+  attachPollMessage,
   setGuildAllowedDecks,
   setGuildDefaultDeck,
   startUserPlay,
@@ -28,6 +32,7 @@ import {
 import {
   buildDailyGameMessage,
   buildDailyResultMessage,
+  buildDeckVoteMessage,
   buildGuildConfigEmbed,
   buildLeaderboardMessage,
   buildScheduleDraftMessage,
@@ -164,6 +169,11 @@ export const quizCommand = {
             .addChoices(...DECK_CHOICES)
         )
     )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('vote')
+        .setDescription("(Admin) Open a poll: members vote for tomorrow's deck")
+    )
     .addSubcommandGroup((group) =>
       group
         .setName('config')
@@ -221,6 +231,8 @@ export const quizCommand = {
           return await handleLeaderboard(interaction);
         case 'schedule':
           return await handleSchedule(interaction);
+        case 'vote':
+          return await handleVote(interaction);
         default:
           return await interaction.reply({
             content: 'Unknown subcommand',
@@ -602,6 +614,65 @@ async function handleConfig(
   }
 
   return await interaction.reply({ content: 'Unknown config subcommand', ephemeral: true });
+}
+
+/**
+ * Compute the ballot for a guild's deck vote. Prefer the guild's allow-list;
+ * fall back to all named decks. Excludes the '' "all decks" sentinel because
+ * picking "all" defeats the point of voting on a deck.
+ */
+export function getBallotDecks(guildId: string): string[] {
+  const cfg = getGuildConfig(guildId);
+  const candidates = cfg.allowedDecks.length > 0 ? cfg.allowedDecks : (KNOWN_DECKS as readonly string[]);
+  return candidates.filter((d) => d !== '');
+}
+
+/**
+ * Admin: open a deck vote for tomorrow. Posts a public embed in the channel.
+ */
+async function handleVote(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  if (!interaction.guildId) {
+    return await interaction.reply({
+      content: '⚠️ Run this in a server channel.',
+      ephemeral: true,
+    });
+  }
+  if (!ensureAdmin(interaction)) {
+    return await interaction.reply({
+      content: '🚫 Need **Manage Server** permission to start a vote.',
+      ephemeral: true,
+    });
+  }
+
+  ensureDailyQuizTables();
+  const date = tomorrowKey();
+  const ballot = getBallotDecks(interaction.guildId);
+  if (ballot.length === 0) {
+    return await interaction.reply({
+      content: '⚠️ No decks available to vote on. Add some with `/quiz config allow-decks`.',
+      ephemeral: true,
+    });
+  }
+
+  const existing = getDeckPoll(interaction.guildId, date);
+  if (existing && existing.status === 'closed') {
+    return await interaction.reply({
+      content: `⚠️ Tomorrow's vote is already closed (winner: **${existing.winningDeck || 'none'}**). Try again tomorrow.`,
+      ephemeral: true,
+    });
+  }
+
+  const poll = getOrCreateDeckPoll(interaction.guildId, date, interaction.user.id);
+  const tallies = getDeckVoteTallies(poll.id, ballot);
+  const payload = buildDeckVoteMessage(poll, tallies);
+
+  // Reply publicly so members can vote, then record the message id so the
+  // button handlers know which message to edit.
+  const sent = await interaction.reply({ ...payload, fetchReply: true });
+  attachPollMessage(poll.id, interaction.channelId, sent.id);
+  return undefined;
 }
 
 /**

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -1,20 +1,12 @@
 import {
   SlashCommandBuilder,
   ChatInputCommandInteraction,
-  EmbedBuilder,
   InteractionResponse,
-  TextChannel,
+  Channel,
 } from 'discord.js';
 import { logger } from '@coachartie/shared';
 import { quizSessionManager, QuizSession } from '../services/quiz-session-manager.js';
-
-const AVAILABLE_DECKS = [
-  'COMPUTERS',
-  'ELECTRICAL_AND_RADIO',
-  'POLITICS',
-  'RUBIKS_2x2',
-  'SAR_AND_WILDERNESS',
-];
+import { buildLiveQuizMessage, buildQuizSummary } from '../services/quiz-embed.js';
 
 export const quizCommand = {
   data: new SlashCommandBuilder()
@@ -97,6 +89,50 @@ export const quizCommand = {
   },
 };
 
+/**
+ * Edit the live quiz embed in place. Falls back to a new message if the
+ * tracked host message is gone.
+ */
+export async function refreshLiveQuiz(channel: Channel, session: QuizSession): Promise<void> {
+  if (!('send' in channel) || !channel.isTextBased()) return;
+  const payload = buildLiveQuizMessage(session);
+
+  if (session.questionMessageId) {
+    try {
+      const existing = await channel.messages.fetch(session.questionMessageId);
+      await existing.edit(payload);
+      return;
+    } catch (e) {
+      logger.warn('Quiz embed message gone, re-posting:', e);
+    }
+  }
+  const sent = await channel.send(payload);
+  quizSessionManager.setQuestionMessage(session.channelId, sent.id);
+}
+
+/**
+ * End the quiz, replace the live embed with a shareable summary card.
+ */
+export async function postQuizSummary(channel: Channel, channelId: string): Promise<void> {
+  if (!('send' in channel) || !channel.isTextBased()) return;
+  const session = quizSessionManager.getSession(channelId);
+  const finalScores = quizSessionManager.endQuiz(channelId);
+  if (!session || !finalScores) return;
+
+  const payload = buildQuizSummary(session, finalScores);
+
+  if (session.questionMessageId) {
+    try {
+      const existing = await channel.messages.fetch(session.questionMessageId);
+      await existing.edit(payload);
+      return;
+    } catch (e) {
+      logger.warn('Quiz host message missing for summary, posting fresh:', e);
+    }
+  }
+  await channel.send(payload);
+}
+
 async function handleStart(
   interaction: ChatInputCommandInteraction
 ): Promise<InteractionResponse<boolean> | undefined> {
@@ -108,7 +144,6 @@ async function handleStart(
   const questionCount = questionsOption || 10;
   const aiJudge = aiJudgeOption ?? false;
 
-  // Check if quiz already active
   if (quizSessionManager.hasActiveQuiz(interaction.channelId)) {
     return await interaction.reply({
       content: '❌ A quiz is already active in this channel! Use `/quiz stop` to end it first.',
@@ -116,7 +151,6 @@ async function handleStart(
     });
   }
 
-  // Defer reply since starting quiz might take a moment
   await interaction.deferReply();
 
   try {
@@ -127,40 +161,20 @@ async function handleStart(
       questionCount,
       aiJudge,
       onTimeout: async (timedOutSession: QuizSession) => {
-        // Handle timeout - reveal answer and move to next question
         try {
           const { answer, nextSession } = await quizSessionManager.handleTimeout(
             interaction.channelId
           );
+          quizSessionManager.setBanner(
+            interaction.channelId,
+            `⏰ Time's up! The answer was **${answer}**`
+          );
 
-          let response = `⏰ **Time's up!**\nThe answer was: **${answer}**\n`;
-          response += `📊 ${quizSessionManager.formatScores(timedOutSession.scores, undefined, timedOutSession.streaks)}\n`;
-
-          if (nextSession && nextSession.currentCard) {
-            response += `\n---\n\n`;
-            response += `**Question ${nextSession.questionNumber}/${nextSession.totalQuestions}**\n`;
-            response += nextSession.currentCard.front;
-            if (nextSession.currentCard.hints.length > 0) {
-              response += `\n\n_💡 Hints available: ${nextSession.currentCard.hints.length}_`;
-            }
+          if (!interaction.channel) return;
+          if (nextSession) {
+            await refreshLiveQuiz(interaction.channel, nextSession);
           } else {
-            // Quiz ended
-            const scores = quizSessionManager.endQuiz(interaction.channelId);
-            if (scores && scores.size > 0) {
-              response += `\n🏁 **Quiz Complete!**\n`;
-              const winners = quizSessionManager.getWinners(scores);
-              if (winners.length === 1) {
-                response += `🎉 **Winner: <@${winners[0]}>!**`;
-              } else if (winners.length > 1) {
-                response += `🎉 **It's a tie! Winners: ${winners.map((w: string) => `<@${w}>`).join(', ')}**`;
-              }
-            } else {
-              response += `\n🏁 **Quiz Complete!** No one scored any points.`;
-            }
-          }
-
-          if (interaction.channel && 'send' in interaction.channel) {
-            await interaction.channel.send(response);
+            await postQuizSummary(interaction.channel, interaction.channelId);
           }
         } catch (e) {
           logger.error('Failed to handle quiz timeout:', e);
@@ -168,34 +182,15 @@ async function handleStart(
       },
     });
 
-    const deckDisplay = session.deckId || 'All Decks';
+    quizSessionManager.rememberUsername(
+      interaction.channelId,
+      interaction.user.id,
+      interaction.user.username
+    );
 
-    const judgeLine = session.aiJudge
-      ? '\n**AI Judge:** on — fuzzy/equivalent answers accepted'
-      : '';
-
-    const embed = new EmbedBuilder()
-      .setColor(0x00ff00)
-      .setTitle('🎮 Quiz Started!')
-      .setDescription(
-        `**Deck:** ${deckDisplay}\n**Questions:** ${session.totalQuestions}${judgeLine}\n\nType your answers in chat — first correct answer wins, build a 🔥 streak for bragging rights!`
-      )
-      .setFooter({ text: `Started by ${interaction.user.username}` })
-      .setTimestamp();
-
-    await interaction.editReply({ embeds: [embed] });
-
-    // Send first question as a separate message
-    if (session.currentCard) {
-      let questionMsg = `**Question 1/${session.totalQuestions}**\n`;
-      questionMsg += session.currentCard.front;
-      if (session.currentCard.hints.length > 0) {
-        questionMsg += `\n\n_💡 Hints available: ${session.currentCard.hints.length}_`;
-      }
-      if (interaction.channel && 'send' in interaction.channel) {
-        await interaction.channel.send(questionMsg);
-      }
-    }
+    const payload = buildLiveQuizMessage(session);
+    const sent = await interaction.editReply(payload);
+    quizSessionManager.setQuestionMessage(interaction.channelId, sent.id);
 
     return undefined;
   } catch (error) {
@@ -210,51 +205,20 @@ async function handleStart(
 async function handleStop(
   interaction: ChatInputCommandInteraction
 ): Promise<InteractionResponse<boolean> | undefined> {
-  const scores = quizSessionManager.endQuiz(interaction.channelId);
-
-  if (!scores) {
+  const session = quizSessionManager.getSession(interaction.channelId);
+  if (!session) {
     return await interaction.reply({
       content: '❌ No active quiz in this channel.',
       ephemeral: true,
     });
   }
 
-  const sessionBefore = quizSessionManager.getSession(interaction.channelId);
-  const bestStreaks = sessionBefore ? new Map(sessionBefore.bestStreaks) : new Map<string, number>();
-
-  const embed = new EmbedBuilder()
-    .setColor(0xff9900)
-    .setTitle('🛑 Quiz Stopped')
-    .setDescription(
-      scores.size > 0
-        ? `**Final Scores:**\n${quizSessionManager.formatScores(scores)}`
-        : 'No scores recorded.'
-    )
-    .setFooter({ text: `Stopped by ${interaction.user.username}` })
-    .setTimestamp();
-
-  if (scores.size > 0) {
-    const winners = quizSessionManager.getWinners(scores);
-    if (winners.length === 1) {
-      embed.addFields({ name: '🏆 Winner', value: `<@${winners[0]}>` });
-    } else if (winners.length > 1) {
-      embed.addFields({
-        name: '🏆 Tied Winners',
-        value: winners.map((w: string) => `<@${w}>`).join(', '),
-      });
-    }
+  await interaction.deferReply();
+  if (interaction.channel) {
+    await postQuizSummary(interaction.channel, interaction.channelId);
   }
-
-  const streakLeaders = quizSessionManager.getStreakLeaders(bestStreaks);
-  if (streakLeaders.length > 0) {
-    const top = streakLeaders.slice(0, 3);
-    embed.addFields({
-      name: '🔥 Streak Leaders',
-      value: top.map(([uid, streak]) => `<@${uid}>: ${streak} in a row`).join('\n'),
-    });
-  }
-
-  return await interaction.reply({ embeds: [embed] });
+  await interaction.editReply({ content: `🛑 Quiz ended by ${interaction.user.username}.` });
+  return undefined;
 }
 
 async function handleScores(
@@ -269,29 +233,8 @@ async function handleScores(
     });
   }
 
-  const embed = new EmbedBuilder()
-    .setColor(0x0099ff)
-    .setTitle('📊 Quiz Scores')
-    .setDescription(
-      session.scores.size > 0
-        ? quizSessionManager.formatScores(session.scores, undefined, session.streaks)
-        : 'No scores yet - be the first to answer!'
-    )
-    .addFields(
-      {
-        name: 'Progress',
-        value: `Question ${session.questionNumber}/${session.totalQuestions}`,
-        inline: true,
-      },
-      {
-        name: 'Deck',
-        value: session.deckId || 'All Decks',
-        inline: true,
-      }
-    )
-    .setTimestamp();
-
-  return await interaction.reply({ embeds: [embed] });
+  const payload = buildLiveQuizMessage(session);
+  return await interaction.reply({ ...payload, ephemeral: true });
 }
 
 async function handleSkip(
@@ -306,40 +249,19 @@ async function handleSkip(
     });
   }
 
-  await interaction.reply({
-    content: `⏭️ **Question skipped!**\nThe answer was: **${skippedAnswer}**`,
-  });
+  await interaction.deferReply({ ephemeral: true });
+  quizSessionManager.setBanner(
+    interaction.channelId,
+    `⏭️ Skipped by ${interaction.user.username}. Answer was **${skippedAnswer}**`
+  );
 
-  if (session && session.currentCard) {
-    // Send next question
-    let questionMsg = `\n**Question ${session.questionNumber}/${session.totalQuestions}**\n`;
-    questionMsg += session.currentCard.front;
-    if (session.currentCard.hints.length > 0) {
-      questionMsg += `\n\n_💡 Hints available: ${session.currentCard.hints.length}_`;
-    }
-    if (interaction.channel && 'send' in interaction.channel) {
-      await interaction.channel.send(questionMsg);
-    }
-  } else {
-    // Quiz ended
-    const scores = quizSessionManager.getScores(interaction.channelId);
-    if (scores) {
-      const finalScores = quizSessionManager.endQuiz(interaction.channelId);
-      if (finalScores && finalScores.size > 0) {
-        let endMsg = `🏁 **Quiz Complete!**\n`;
-        endMsg += quizSessionManager.formatScores(finalScores);
-        const winners = quizSessionManager.getWinners(finalScores);
-        if (winners.length === 1) {
-          endMsg += `\n\n🎉 **Winner: <@${winners[0]}>!**`;
-        } else if (winners.length > 1) {
-          endMsg += `\n\n🎉 **It's a tie! Winners: ${winners.map((w: string) => `<@${w}>`).join(', ')}**`;
-        }
-        if (interaction.channel && 'send' in interaction.channel) {
-          await interaction.channel.send(endMsg);
-        }
-      }
+  if (interaction.channel) {
+    if (session) {
+      await refreshLiveQuiz(interaction.channel, session);
+    } else {
+      await postQuizSummary(interaction.channel, interaction.channelId);
     }
   }
-
+  await interaction.editReply({ content: '⏭️ Skipped.' });
   return undefined;
 }

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -7,6 +7,18 @@ import {
 import { logger } from '@coachartie/shared';
 import { quizSessionManager, QuizSession } from '../services/quiz-session-manager.js';
 import { buildLiveQuizMessage, buildQuizSummary } from '../services/quiz-embed.js';
+import {
+  ensureDailyQuizTables,
+  getOrCreateDailyPuzzle,
+  getUserPlay,
+  startUserPlay,
+  todayKey,
+  DAILY_QUESTION_COUNT,
+} from '../services/daily-quiz.js';
+import {
+  buildDailyGameMessage,
+  buildDailyResultMessage,
+} from '../services/daily-quiz-embed.js';
 
 export const quizCommand = {
   data: new SlashCommandBuilder()
@@ -53,6 +65,25 @@ export const quizCommand = {
     )
     .addSubcommand((subcommand) =>
       subcommand.setName('skip').setDescription('Skip the current question')
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('daily')
+        .setDescription("Play today's solo daily quiz (Wordle-style — share your result after)")
+        .addStringOption((option) =>
+          option
+            .setName('deck')
+            .setDescription('Which deck to play today (default: all)')
+            .setRequired(false)
+            .addChoices(
+              { name: 'All Decks (Random)', value: 'all' },
+              { name: 'Computers', value: 'COMPUTERS' },
+              { name: 'Electrical & Radio', value: 'ELECTRICAL_AND_RADIO' },
+              { name: 'Politics', value: 'POLITICS' },
+              { name: "Rubik's 2x2", value: 'RUBIKS_2x2' },
+              { name: 'Search & Rescue', value: 'SAR_AND_WILDERNESS' }
+            )
+        )
     ),
 
   async execute(
@@ -70,6 +101,8 @@ export const quizCommand = {
           return await handleScores(interaction);
         case 'skip':
           return await handleSkip(interaction);
+        case 'daily':
+          return await handleDaily(interaction);
         default:
           return await interaction.reply({
             content: 'Unknown subcommand',
@@ -263,5 +296,58 @@ async function handleSkip(
     }
   }
   await interaction.editReply({ content: '⏭️ Skipped.' });
+  return undefined;
+}
+
+/**
+ * Solo, async, once-per-day quiz. Ephemeral — only the invoker sees their
+ * game state. Wordle-style: everyone gets the same N cards for the day,
+ * play whenever, opt-in share to the channel.
+ */
+async function handleDaily(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  const deckOption = interaction.options.getString('deck');
+  const deck = deckOption && deckOption !== 'all' ? deckOption : '';
+  const date = todayKey();
+
+  await interaction.deferReply({ ephemeral: true });
+  ensureDailyQuizTables();
+
+  let puzzle;
+  try {
+    puzzle = await getOrCreateDailyPuzzle(date, deck);
+  } catch (e) {
+    logger.error('Failed to fetch daily puzzle:', e);
+    await interaction.editReply({
+      content: '❌ Failed to load today\'s puzzle. Try again in a minute.',
+    });
+    return undefined;
+  }
+
+  if (!puzzle || puzzle.cards.length === 0) {
+    await interaction.editReply({
+      content: '❌ Could not load today\'s puzzle. The flashcard API may be down.',
+    });
+    return undefined;
+  }
+
+  let play = getUserPlay(interaction.user.id, date, deck);
+  if (!play) {
+    play = startUserPlay(interaction.user.id, interaction.user.username, date, deck);
+  }
+
+  if (play.completed) {
+    const payload = buildDailyResultMessage(play, puzzle, interaction.user.username);
+    await interaction.editReply(payload);
+    return undefined;
+  }
+
+  // Truncate cards array to the question count we're enforcing — guards
+  // against any oddness in cached puzzles from earlier versions.
+  puzzle.cards = puzzle.cards.slice(0, DAILY_QUESTION_COUNT);
+
+  const payload = buildDailyGameMessage(play, puzzle);
+  await interaction.editReply(payload);
   return undefined;
 }

--- a/packages/discord/src/commands/quiz.ts
+++ b/packages/discord/src/commands/quiz.ts
@@ -16,11 +16,15 @@ import {
   getGuildConfig,
   getOrCreateDailyPuzzle,
   getOrCreateDeckPoll,
+  getMostRecentCompletedPlay,
   getServerLeaderboard,
   getUserPlay,
   isDeckAllowedForGuild,
   KNOWN_DECKS,
   attachPollMessage,
+  ACHIEVEMENTS,
+  computeAchievements,
+  computeUserStats,
   setGuildAllowedDecks,
   setGuildDefaultDeck,
   startUserPlay,
@@ -30,11 +34,13 @@ import {
   type LeaderboardScope,
 } from '../services/daily-quiz.js';
 import {
+  buildChallengeMessage,
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDeckVoteMessage,
   buildGuildConfigEmbed,
   buildLeaderboardMessage,
+  buildProfileMessage,
   buildScheduleDraftMessage,
 } from '../services/daily-quiz-embed.js';
 
@@ -174,6 +180,25 @@ export const quizCommand = {
         .setName('vote')
         .setDescription("(Admin) Open a poll: members vote for tomorrow's deck")
     )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('me')
+        .setDescription('Show your (or another player\'s) daily-quiz profile')
+        .addUserOption((option) =>
+          option.setName('user').setDescription('Whose profile to view').setRequired(false)
+        )
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('challenge')
+        .setDescription('Challenge a friend to beat your daily quiz score')
+        .addUserOption((option) =>
+          option.setName('user').setDescription('Who to challenge').setRequired(true)
+        )
+        .addStringOption((option) =>
+          option.setName('note').setDescription('Optional trash talk').setRequired(false)
+        )
+    )
     .addSubcommandGroup((group) =>
       group
         .setName('config')
@@ -233,6 +258,10 @@ export const quizCommand = {
           return await handleSchedule(interaction);
         case 'vote':
           return await handleVote(interaction);
+        case 'me':
+          return await handleMe(interaction);
+        case 'challenge':
+          return await handleChallenge(interaction);
         default:
           return await interaction.reply({
             content: 'Unknown subcommand',
@@ -673,6 +702,54 @@ async function handleVote(
   const sent = await interaction.reply({ ...payload, fetchReply: true });
   attachPollMessage(poll.id, interaction.channelId, sent.id);
   return undefined;
+}
+
+/**
+ * Public profile card — flexes lifetime stats + badges. Designed to be
+ * screenshotted and shared elsewhere ("oh, what bot is that?").
+ */
+async function handleMe(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  ensureDailyQuizTables();
+  const targetUser = interaction.options.getUser('user') || interaction.user;
+  const stats = computeUserStats(targetUser.id, interaction.guildId);
+  const earned = ACHIEVEMENTS.filter((a) => computeAchievements(stats).has(a.id));
+  const payload = buildProfileMessage(targetUser, stats, earned);
+  return await interaction.reply(payload);
+}
+
+/**
+ * Tag a friend with a "beat my score" public callout. The caller's most
+ * recent completed play (any deck) is included so the target sees what
+ * they're up against.
+ */
+async function handleChallenge(
+  interaction: ChatInputCommandInteraction
+): Promise<InteractionResponse<boolean> | undefined> {
+  const target = interaction.options.getUser('user', true);
+  if (target.id === interaction.user.id) {
+    return await interaction.reply({
+      content: '⚠️ You can\'t challenge yourself!',
+      ephemeral: true,
+    });
+  }
+  if (target.bot) {
+    return await interaction.reply({
+      content: '⚠️ Bots don\'t play the daily quiz.',
+      ephemeral: true,
+    });
+  }
+  const note = interaction.options.getString('note') || undefined;
+  const recentPlay = getMostRecentCompletedPlay(interaction.user.id, interaction.guildId);
+  const payload = buildChallengeMessage(
+    interaction.user,
+    target,
+    recentPlay,
+    todayKey(),
+    note
+  );
+  return await interaction.reply(payload);
 }
 
 /**

--- a/packages/discord/src/handlers/interaction-handler.ts
+++ b/packages/discord/src/handlers/interaction-handler.ts
@@ -5,6 +5,7 @@ import {
   ChatInputCommandInteraction,
   ButtonInteraction,
   SelectMenuInteraction,
+  ModalSubmitInteraction,
 } from 'discord.js';
 import { logger } from '@coachartie/shared';
 import { linkPhoneCommand } from '../commands/link-phone.js';
@@ -21,7 +22,23 @@ import { debugCommand } from '../commands/debug.js';
 import * as syncDiscussionsCommand from '../commands/sync-discussions.js';
 import { quizCommand, refreshLiveQuiz, postQuizSummary } from '../commands/quiz.js';
 import { parseQuizButtonId } from '../services/quiz-embed.js';
-import { quizSessionManager } from '../services/quiz-session-manager.js';
+import { quizSessionManager, isCorrectAnswer } from '../services/quiz-session-manager.js';
+import {
+  parseDailyCustomId,
+  buildDailyGameMessage,
+  buildDailyResultMessage,
+  buildDailyShareMessage,
+  buildGuessModal,
+  DAILY_MODAL_INPUT,
+} from '../services/daily-quiz-embed.js';
+import {
+  getOrCreateDailyPuzzle,
+  getUserPlay,
+  recordGuess,
+  markCompleted,
+  markShared,
+  DAILY_QUESTION_COUNT,
+} from '../services/daily-quiz.js';
 import { watchRepoCommand } from '../commands/watch-repo.js';
 import { unwatchRepoCommand } from '../commands/unwatch-repo.js';
 import { listWatchesCommand } from '../commands/list-watches.js';
@@ -61,6 +78,8 @@ export function setupInteractionHandler(client: Client) {
       await handleButtonInteraction(interaction);
     } else if (interaction.isStringSelectMenu()) {
       await handleSelectMenuInteraction(interaction);
+    } else if (interaction.isModalSubmit()) {
+      await handleModalSubmit(interaction);
     }
   });
 
@@ -189,6 +208,13 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
   const quizAction = parseQuizButtonId(interaction.customId);
   if (quizAction) {
     await handleQuizButton(interaction, quizAction);
+    return;
+  }
+
+  // Daily-quiz buttons (Guess opens modal, Share posts public card).
+  const dailyId = parseDailyCustomId(interaction.customId);
+  if (dailyId) {
+    await handleDailyQuizButton(interaction, dailyId);
     return;
   }
 
@@ -353,6 +379,166 @@ async function handleQuizButton(
       }
     } catch {
       // already replied
+    }
+  }
+}
+
+/**
+ * Daily quiz button dispatcher. Guess → opens a modal. Share → posts the
+ * public emoji-grid card and disables the share button on the ephemeral.
+ */
+async function handleDailyQuizButton(
+  interaction: ButtonInteraction,
+  parsed: NonNullable<ReturnType<typeof parseDailyCustomId>>
+): Promise<void> {
+  const { action, date, deck } = parsed;
+  const userId = interaction.user.id;
+
+  try {
+    if (action === 'guess') {
+      const play = getUserPlay(userId, date, deck);
+      if (!play || play.completed) {
+        await interaction.reply({
+          content: '⚠️ This game is finished. Start tomorrow\'s with `/quiz daily`.',
+          ephemeral: true,
+        });
+        return;
+      }
+      await interaction.showModal(buildGuessModal(date, deck, play.currentQuestion + 1));
+      return;
+    }
+
+    if (action === 'share') {
+      const play = getUserPlay(userId, date, deck);
+      if (!play || !play.completed) {
+        await interaction.reply({
+          content: '⚠️ Finish the quiz first.',
+          ephemeral: true,
+        });
+        return;
+      }
+      if (play.shared) {
+        await interaction.reply({ content: 'Already shared today.', ephemeral: true });
+        return;
+      }
+
+      await interaction.deferUpdate();
+
+      if (interaction.channel && 'send' in interaction.channel) {
+        await interaction.channel.send(buildDailyShareMessage(play, interaction.user.username));
+      }
+      markShared(userId, date, deck);
+
+      const puzzle = await getOrCreateDailyPuzzle(date, deck);
+      if (puzzle) {
+        const refreshed = getUserPlay(userId, date, deck);
+        if (refreshed) {
+          await interaction.editReply(
+            buildDailyResultMessage(refreshed, puzzle, interaction.user.username)
+          );
+        }
+      }
+      return;
+    }
+
+    // replay or unknown: just acknowledge
+    await interaction.reply({
+      content: '🔁 Come back tomorrow for the next daily!',
+      ephemeral: true,
+    });
+  } catch (error) {
+    logger.error('Daily quiz button error:', error);
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: '❌ Something went wrong with that action.',
+          ephemeral: true,
+        });
+      }
+    } catch {
+      // already responded
+    }
+  }
+}
+
+/**
+ * Modal submit dispatcher. Only handles the daily quiz answer modal for now.
+ */
+async function handleModalSubmit(interaction: ModalSubmitInteraction): Promise<void> {
+  const parsed = parseDailyCustomId(interaction.customId);
+  if (!parsed || parsed.action !== 'modal') {
+    await interaction.reply({
+      content: '⚠️ Unknown modal submission.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const { date, deck } = parsed;
+  const userId = interaction.user.id;
+  const guess = interaction.fields.getTextInputValue(DAILY_MODAL_INPUT).trim();
+
+  try {
+    const puzzle = await getOrCreateDailyPuzzle(date, deck);
+    const play = getUserPlay(userId, date, deck);
+    if (!puzzle || !play) {
+      await interaction.reply({
+        content: '⚠️ No active daily quiz for you. Run `/quiz daily` to start.',
+        ephemeral: true,
+      });
+      return;
+    }
+    if (play.completed) {
+      await interaction.reply({
+        content: '⚠️ Today\'s game is already finished.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const card = puzzle.cards[play.currentQuestion];
+    if (!card) {
+      await interaction.reply({
+        content: '⚠️ Out of questions — finishing up.',
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const correct = isCorrectAnswer(guess, card.back);
+    let updatedPlay = recordGuess(userId, date, deck, guess, correct);
+    if (!updatedPlay) {
+      await interaction.reply({ content: '❌ Failed to record guess.', ephemeral: true });
+      return;
+    }
+
+    const isLast = updatedPlay.currentQuestion >= DAILY_QUESTION_COUNT;
+    if (isLast) {
+      updatedPlay = markCompleted(userId, date, deck) ?? updatedPlay;
+    }
+    const payload = isLast
+      ? buildDailyResultMessage(updatedPlay, puzzle, interaction.user.username)
+      : buildDailyGameMessage(updatedPlay, puzzle);
+
+    // Edit the ephemeral message the Guess button lived on. Only available
+    // when the modal was launched from a message component (which it was —
+    // we showed it from a button). Falls back to a fresh ephemeral reply.
+    if (interaction.isFromMessage()) {
+      await interaction.update(payload);
+    } else {
+      await interaction.reply({ ...payload, ephemeral: true });
+    }
+  } catch (error) {
+    logger.error('Daily quiz modal submit error:', error);
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: '❌ Failed to record your guess.',
+          ephemeral: true,
+        });
+      }
+    } catch {
+      // already responded
     }
   }
 }

--- a/packages/discord/src/handlers/interaction-handler.ts
+++ b/packages/discord/src/handlers/interaction-handler.ts
@@ -36,6 +36,7 @@ import {
   parseDailyCustomId,
   parseScheduleCustomId,
   parseVoteCustomId,
+  buildAchievementUnlockMessage,
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
@@ -47,6 +48,8 @@ import {
 import {
   castDeckVote,
   closeDeckPoll,
+  computeUserStats,
+  diffAchievements,
   fetchUniqueCards,
   getDeckPollById,
   getDeckVoteTallies,
@@ -718,9 +721,17 @@ async function handleModalSubmit(interaction: ModalSubmitInteraction): Promise<v
     }
 
     const isLast = updatedPlay.currentQuestion >= DAILY_QUESTION_COUNT;
+
+    // Diff achievements across the markCompleted boundary so we can post a
+    // celebratory message in channel for any badges this play unlocked.
+    let unlockedAchievements: ReturnType<typeof diffAchievements> = [];
     if (isLast) {
+      const before = computeUserStats(userId, interaction.guildId);
       updatedPlay = markCompleted(userId, date, deck) ?? updatedPlay;
+      const after = computeUserStats(userId, interaction.guildId);
+      unlockedAchievements = diffAchievements(before, after);
     }
+
     const payload = isLast
       ? buildDailyResultMessage(updatedPlay, puzzle, interaction.user.username)
       : buildDailyGameMessage(updatedPlay, puzzle);
@@ -732,6 +743,18 @@ async function handleModalSubmit(interaction: ModalSubmitInteraction): Promise<v
       await interaction.update(payload);
     } else {
       await interaction.reply({ ...payload, ephemeral: true });
+    }
+
+    // Public celebration — drops in the same channel where they ran /quiz daily.
+    // Social proof + tags the player so it surfaces in their notifications.
+    if (unlockedAchievements.length > 0 && interaction.channel && 'send' in interaction.channel) {
+      try {
+        await interaction.channel.send(
+          buildAchievementUnlockMessage(interaction.user, unlockedAchievements)
+        );
+      } catch (e) {
+        logger.warn('Failed to post achievement unlock:', e);
+      }
     }
   } catch (error) {
     logger.error('Daily quiz modal submit error:', error);

--- a/packages/discord/src/handlers/interaction-handler.ts
+++ b/packages/discord/src/handlers/interaction-handler.ts
@@ -28,21 +28,28 @@ import {
   getScheduleDraft,
   setScheduleDraft,
   clearScheduleDraft,
+  getBallotDecks,
 } from '../commands/quiz.js';
 import { parseQuizButtonId } from '../services/quiz-embed.js';
 import { quizSessionManager, isCorrectAnswer } from '../services/quiz-session-manager.js';
 import {
   parseDailyCustomId,
   parseScheduleCustomId,
+  parseVoteCustomId,
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
+  buildDeckVoteMessage,
   buildGuessModal,
   buildScheduleDraftMessage,
   DAILY_MODAL_INPUT,
 } from '../services/daily-quiz-embed.js';
 import {
+  castDeckVote,
+  closeDeckPoll,
   fetchUniqueCards,
+  getDeckPollById,
+  getDeckVoteTallies,
   getOrCreateDailyPuzzle,
   getUserPlay,
   recordGuess,
@@ -234,6 +241,13 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
   const scheduleId = parseScheduleCustomId(interaction.customId);
   if (scheduleId) {
     await handleScheduleButton(interaction, scheduleId);
+    return;
+  }
+
+  // Deck vote buttons (Cast / Close).
+  const voteId = parseVoteCustomId(interaction.customId);
+  if (voteId) {
+    await handleVoteButton(interaction, voteId);
     return;
   }
 
@@ -551,6 +565,103 @@ async function handleScheduleButton(
       }
     } catch {
       // already replied
+    }
+  }
+}
+
+/**
+ * Deck vote buttons. Cast records/updates a member's vote; Close (admin only)
+ * tallies, picks the winner, fetches cards, and schedules tomorrow's puzzle.
+ */
+async function handleVoteButton(
+  interaction: ButtonInteraction,
+  parsed: NonNullable<ReturnType<typeof parseVoteCustomId>>
+): Promise<void> {
+  const poll = getDeckPollById(parsed.pollId);
+  if (!poll) {
+    await interaction.reply({ content: '⚠️ Poll not found.', ephemeral: true });
+    return;
+  }
+
+  // The ballot at vote time is whatever the guild's current allow-list says.
+  // Stored votes for since-removed decks still tally; the embed just won't
+  // render them. Good enough.
+  const ballot = getBallotDecks(poll.guildId);
+
+  try {
+    if (parsed.action === 'cast') {
+      if (poll.status !== 'open') {
+        await interaction.reply({
+          content: '⚠️ Voting is closed for this poll.',
+          ephemeral: true,
+        });
+        return;
+      }
+      await interaction.deferUpdate();
+      castDeckVote(poll.id, interaction.user.id, parsed.deck);
+      const tallies = getDeckVoteTallies(poll.id, ballot);
+      await interaction.editReply(buildDeckVoteMessage(poll, tallies));
+      return;
+    }
+
+    if (parsed.action === 'close') {
+      if (!interaction.memberPermissions?.has(PermissionsBitField.Flags.ManageGuild)) {
+        await interaction.reply({
+          content: '🚫 Only admins can close the vote.',
+          ephemeral: true,
+        });
+        return;
+      }
+      if (poll.status === 'closed') {
+        await interaction.reply({
+          content: '⚠️ Vote is already closed.',
+          ephemeral: true,
+        });
+        return;
+      }
+
+      await interaction.deferUpdate();
+      const { winningDeck, tallies } = closeDeckPoll(poll.id, ballot);
+
+      // Auto-schedule the winning deck's cards as tomorrow's puzzle. If the
+      // fetch fails or there were no votes, we still publish the closed
+      // embed — admin can `/quiz schedule` manually.
+      let scheduledOk = false;
+      if (winningDeck) {
+        try {
+          const cards = await fetchUniqueCards(winningDeck, DAILY_QUESTION_COUNT);
+          if (cards.length > 0) {
+            scheduleDailyPuzzle(
+              poll.targetDate,
+              winningDeck,
+              poll.guildId,
+              cards,
+              interaction.user.id
+            );
+            scheduledOk = true;
+          }
+        } catch (e) {
+          logger.warn('Vote close: failed to fetch cards for winning deck:', e);
+        }
+      }
+
+      const refreshed = getDeckPollById(poll.id) ?? poll;
+      await interaction.editReply(
+        buildDeckVoteMessage(refreshed, tallies, { winningDeck, scheduledOk })
+      );
+      return;
+    }
+  } catch (error) {
+    logger.error('Vote button error:', error);
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: '❌ Something went wrong handling that vote.',
+          ephemeral: true,
+        });
+      }
+    } catch {
+      // already responded
     }
   }
 }

--- a/packages/discord/src/handlers/interaction-handler.ts
+++ b/packages/discord/src/handlers/interaction-handler.ts
@@ -6,6 +6,7 @@ import {
   ButtonInteraction,
   SelectMenuInteraction,
   ModalSubmitInteraction,
+  PermissionsBitField,
 } from 'discord.js';
 import { logger } from '@coachartie/shared';
 import { linkPhoneCommand } from '../commands/link-phone.js';
@@ -20,23 +21,34 @@ import { memoryCommand } from '../commands/memory.js';
 import { usageCommand } from '../commands/usage.js';
 import { debugCommand } from '../commands/debug.js';
 import * as syncDiscussionsCommand from '../commands/sync-discussions.js';
-import { quizCommand, refreshLiveQuiz, postQuizSummary } from '../commands/quiz.js';
+import {
+  quizCommand,
+  refreshLiveQuiz,
+  postQuizSummary,
+  getScheduleDraft,
+  setScheduleDraft,
+  clearScheduleDraft,
+} from '../commands/quiz.js';
 import { parseQuizButtonId } from '../services/quiz-embed.js';
 import { quizSessionManager, isCorrectAnswer } from '../services/quiz-session-manager.js';
 import {
   parseDailyCustomId,
+  parseScheduleCustomId,
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
   buildGuessModal,
+  buildScheduleDraftMessage,
   DAILY_MODAL_INPUT,
 } from '../services/daily-quiz-embed.js';
 import {
+  fetchUniqueCards,
   getOrCreateDailyPuzzle,
   getUserPlay,
   recordGuess,
   markCompleted,
   markShared,
+  scheduleDailyPuzzle,
   DAILY_QUESTION_COUNT,
 } from '../services/daily-quiz.js';
 import { watchRepoCommand } from '../commands/watch-repo.js';
@@ -215,6 +227,13 @@ async function handleButtonInteraction(interaction: ButtonInteraction) {
   const dailyId = parseDailyCustomId(interaction.customId);
   if (dailyId) {
     await handleDailyQuizButton(interaction, dailyId);
+    return;
+  }
+
+  // Admin scheduler buttons (Shuffle / Use / Cancel).
+  const scheduleId = parseScheduleCustomId(interaction.customId);
+  if (scheduleId) {
+    await handleScheduleButton(interaction, scheduleId);
     return;
   }
 
@@ -457,6 +476,81 @@ async function handleDailyQuizButton(
       }
     } catch {
       // already responded
+    }
+  }
+}
+
+/**
+ * Admin scheduler buttons. Shuffle re-rolls the draft cards; Use these saves
+ * the draft as tomorrow's puzzle for this guild; Cancel discards the draft.
+ */
+async function handleScheduleButton(
+  interaction: ButtonInteraction,
+  parsed: NonNullable<ReturnType<typeof parseScheduleCustomId>>
+): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ content: 'Run this in a server.', ephemeral: true });
+    return;
+  }
+  const perms = interaction.memberPermissions;
+  if (!perms?.has(PermissionsBitField.Flags.ManageGuild)) {
+    await interaction.reply({
+      content: '🚫 Need **Manage Server** permission.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const { action, date, deck } = parsed;
+  const userId = interaction.user.id;
+  const guildId = interaction.guildId;
+
+  try {
+    if (action === 'shuffle') {
+      await interaction.deferUpdate();
+      const cards = await fetchUniqueCards(deck, DAILY_QUESTION_COUNT);
+      setScheduleDraft(userId, guildId, date, deck, cards);
+      await interaction.editReply(buildScheduleDraftMessage(date, deck, cards));
+      return;
+    }
+
+    if (action === 'save') {
+      const draft = getScheduleDraft(userId, guildId, date, deck);
+      if (!draft || draft.length === 0) {
+        await interaction.reply({
+          content: '⚠️ Draft expired — re-run `/quiz schedule`.',
+          ephemeral: true,
+        });
+        return;
+      }
+      await interaction.deferUpdate();
+      scheduleDailyPuzzle(date, deck, guildId, draft, userId);
+      clearScheduleDraft(userId, guildId, date, deck);
+      await interaction.editReply(
+        buildScheduleDraftMessage(date, deck, draft, { saved: true })
+      );
+      return;
+    }
+
+    if (action === 'cancel') {
+      await interaction.deferUpdate();
+      clearScheduleDraft(userId, guildId, date, deck);
+      await interaction.editReply(
+        buildScheduleDraftMessage(date, deck, [], { cancelled: true })
+      );
+      return;
+    }
+  } catch (error) {
+    logger.error('Schedule button error:', error);
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: '❌ Something went wrong.',
+          ephemeral: true,
+        });
+      }
+    } catch {
+      // already replied
     }
   }
 }

--- a/packages/discord/src/handlers/interaction-handler.ts
+++ b/packages/discord/src/handlers/interaction-handler.ts
@@ -19,7 +19,9 @@ import { memoryCommand } from '../commands/memory.js';
 import { usageCommand } from '../commands/usage.js';
 import { debugCommand } from '../commands/debug.js';
 import * as syncDiscussionsCommand from '../commands/sync-discussions.js';
-import { quizCommand } from '../commands/quiz.js';
+import { quizCommand, refreshLiveQuiz, postQuizSummary } from '../commands/quiz.js';
+import { parseQuizButtonId } from '../services/quiz-embed.js';
+import { quizSessionManager } from '../services/quiz-session-manager.js';
 import { watchRepoCommand } from '../commands/watch-repo.js';
 import { unwatchRepoCommand } from '../commands/unwatch-repo.js';
 import { listWatchesCommand } from '../commands/list-watches.js';
@@ -182,6 +184,14 @@ async function handleSlashCommand(interaction: ChatInputCommandInteraction) {
 async function handleButtonInteraction(interaction: ButtonInteraction) {
   const buttonText = (interaction.component as any)?.label || interaction.customId;
 
+  // Quiz buttons own the live embed — handle them before the generic intent
+  // processor so we don't accidentally send "Hint" / "Skip" to the LLM.
+  const quizAction = parseQuizButtonId(interaction.customId);
+  if (quizAction) {
+    await handleQuizButton(interaction, quizAction);
+    return;
+  }
+
   // Check if this is an ask-question response
   if (interaction.customId.startsWith('ask_')) {
     await handleAskQuestionResponse(interaction);
@@ -243,6 +253,108 @@ async function handleSelectMenuInteraction(interaction: SelectMenuInteraction) {
       await interaction.editReply(`🔄 **${selectedLabel}**\n\n${status}`);
     },
   });
+}
+
+/**
+ * Handle the action buttons on the live quiz embed (Hint / Skip / End /
+ * Play Again). Each action mutates the session, then re-renders the embed
+ * in place — the Wordle-style "one host message" pattern.
+ */
+async function handleQuizButton(
+  interaction: ButtonInteraction,
+  action: ReturnType<typeof parseQuizButtonId>
+): Promise<void> {
+  const channelId = interaction.channelId;
+  const channel = interaction.channel;
+  if (!channel) {
+    await interaction.reply({ content: 'No channel context.', ephemeral: true });
+    return;
+  }
+
+  quizSessionManager.rememberUsername(
+    channelId,
+    interaction.user.id,
+    interaction.user.username
+  );
+
+  try {
+    switch (action) {
+      case 'hint': {
+        const session = quizSessionManager.getSession(channelId);
+        if (!session) {
+          await interaction.reply({ content: 'No active quiz.', ephemeral: true });
+          return;
+        }
+        const hint = quizSessionManager.revealHint(channelId);
+        if (!hint) {
+          await interaction.reply({ content: 'No more hints available.', ephemeral: true });
+          return;
+        }
+        await interaction.deferUpdate();
+        await refreshLiveQuiz(channel, session);
+        return;
+      }
+
+      case 'skip': {
+        const session = quizSessionManager.getSession(channelId);
+        if (!session) {
+          await interaction.reply({ content: 'No active quiz.', ephemeral: true });
+          return;
+        }
+        await interaction.deferUpdate();
+        const { skippedAnswer, session: next } =
+          await quizSessionManager.skipQuestion(channelId);
+        quizSessionManager.setBanner(
+          channelId,
+          `⏭️ Skipped by ${interaction.user.username}. Answer was **${skippedAnswer}**`
+        );
+        if (next) {
+          await refreshLiveQuiz(channel, next);
+        } else {
+          await postQuizSummary(channel, channelId);
+        }
+        return;
+      }
+
+      case 'end': {
+        const session = quizSessionManager.getSession(channelId);
+        if (!session) {
+          await interaction.reply({ content: 'No active quiz.', ephemeral: true });
+          return;
+        }
+        await interaction.deferUpdate();
+        quizSessionManager.setBanner(
+          channelId,
+          `🛑 Ended by ${interaction.user.username}`
+        );
+        await postQuizSummary(channel, channelId);
+        return;
+      }
+
+      case 'again': {
+        // Lightweight hint to re-run /quiz start — re-launching a quiz needs
+        // the original options (deck, count, ai_judge) so we don't auto-start
+        // with stale parameters.
+        await interaction.reply({
+          content: '🔁 Run `/quiz start` to play another round!',
+          ephemeral: true,
+        });
+        return;
+      }
+    }
+  } catch (error) {
+    logger.error('Quiz button error:', error);
+    try {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          content: '❌ Something went wrong handling that button.',
+          ephemeral: true,
+        });
+      }
+    } catch {
+      // already replied
+    }
+  }
 }
 
 /**

--- a/packages/discord/src/handlers/message-handler.ts
+++ b/packages/discord/src/handlers/message-handler.ts
@@ -993,32 +993,42 @@ export function setupMessageHandler(client: Client) {
 
     // Check if this channel has an active quiz and if this message is an answer
     if (quizSessionManager.hasActiveQuiz(message.channelId)) {
-      const result = quizSessionManager.checkAnswer(
+      const initial = quizSessionManager.checkAnswer(
         message.channelId,
         message.author.id,
         message.content
       );
 
+      // String match failed but AI judge is on — fire an async LLM check.
+      // Race: another user may answer correctly first; in that case the LLM
+      // result is dropped by the manager.
+      const result =
+        initial === 'maybe'
+          ? await quizSessionManager.checkAnswerWithAI(
+              message.channelId,
+              message.author.id,
+              message.content
+            )
+          : initial;
+
       if (result && result.correct) {
-        // User got the answer right!
         logger.info(
-          `✅ Quiz answer correct! User: ${message.author.tag}, Channel: ${message.channelId}`
+          `✅ Quiz answer correct! User: ${message.author.tag}, Channel: ${message.channelId}, streak=${result.winnerStreak}${result.judgedByAI ? ' (AI)' : ''}`
         );
 
-        // React to the winning message
         try {
-          await message.react('✅');
+          await message.react(result.judgedByAI ? '🤖' : '✅');
         } catch (e) {
           logger.warn('Failed to add reaction to quiz answer:', e);
         }
 
-        // Build response
-        let response = `✅ **${message.author}** got it! (+1 point)\n`;
+        const streakBadge = quizSessionManager.formatStreakBadge(result.winnerStreak);
+        const judgeNote = result.judgedByAI ? ' _(AI judged)_' : '';
+        let response = `✅ **${message.author}** got it! (+1 point)${streakBadge}${judgeNote}\n`;
         response += `Answer: **${result.correctAnswer}**\n\n`;
-        response += `📊 ${quizSessionManager.formatScores(result.currentScores)}\n`;
+        response += `📊 ${quizSessionManager.formatScores(result.currentScores, undefined, result.currentStreaks)}\n`;
 
         if (result.quizEnded) {
-          // Quiz is over
           const scores = quizSessionManager.endQuiz(message.channelId);
           if (scores) {
             response += `\n🏁 **Quiz Complete!**\n`;
@@ -1027,6 +1037,11 @@ export function setupMessageHandler(client: Client) {
               response += `🎉 **Winner: <@${winners[0]}>!**`;
             } else if (winners.length > 1) {
               response += `🎉 **It's a tie! Winners: ${winners.map((w: string) => `<@${w}>`).join(', ')}**`;
+            }
+            const streakLeaders = quizSessionManager.getStreakLeaders(result.bestStreaks);
+            if (streakLeaders.length > 0) {
+              const [topUser, topStreak] = streakLeaders[0];
+              response += `\n🔥 **Streak Champion: <@${topUser}>** — ${topStreak} in a row`;
             }
           }
         } else {

--- a/packages/discord/src/handlers/message-handler.ts
+++ b/packages/discord/src/handlers/message-handler.ts
@@ -34,6 +34,7 @@ import {
 import { getForumTraversal } from '../services/forum-traversal.js';
 import { getMentionProxyService } from '../services/mention-proxy-service.js';
 import { quizSessionManager } from '../services/quiz-session-manager.js';
+import { refreshLiveQuiz, postQuizSummary } from '../commands/quiz.js';
 import Chance from 'chance';
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
@@ -1016,51 +1017,35 @@ export function setupMessageHandler(client: Client) {
           `✅ Quiz answer correct! User: ${message.author.tag}, Channel: ${message.channelId}, streak=${result.winnerStreak}${result.judgedByAI ? ' (AI)' : ''}`
         );
 
+        // React on the user's answer message — the live embed updates separately.
         try {
           await message.react(result.judgedByAI ? '🤖' : '✅');
         } catch (e) {
           logger.warn('Failed to add reaction to quiz answer:', e);
         }
 
+        quizSessionManager.rememberUsername(
+          message.channelId,
+          message.author.id,
+          message.author.username
+        );
+
         const streakBadge = quizSessionManager.formatStreakBadge(result.winnerStreak);
         const judgeNote = result.judgedByAI ? ' _(AI judged)_' : '';
-        let response = `✅ **${message.author}** got it! (+1 point)${streakBadge}${judgeNote}\n`;
-        response += `Answer: **${result.correctAnswer}**\n\n`;
-        response += `📊 ${quizSessionManager.formatScores(result.currentScores, undefined, result.currentStreaks)}\n`;
+        const banner = `✅ **${message.author.username}** got it!${streakBadge}${judgeNote} · Answer: **${result.correctAnswer}**`;
+        quizSessionManager.setBanner(message.channelId, banner);
 
         if (result.quizEnded) {
-          const scores = quizSessionManager.endQuiz(message.channelId);
-          if (scores) {
-            response += `\n🏁 **Quiz Complete!**\n`;
-            const winners = quizSessionManager.getWinners(scores);
-            if (winners.length === 1) {
-              response += `🎉 **Winner: <@${winners[0]}>!**`;
-            } else if (winners.length > 1) {
-              response += `🎉 **It's a tie! Winners: ${winners.map((w: string) => `<@${w}>`).join(', ')}**`;
-            }
-            const streakLeaders = quizSessionManager.getStreakLeaders(result.bestStreaks);
-            if (streakLeaders.length > 0) {
-              const [topUser, topStreak] = streakLeaders[0];
-              response += `\n🔥 **Streak Champion: <@${topUser}>** — ${topStreak} in a row`;
-            }
-          }
+          await postQuizSummary(message.channel, message.channelId);
         } else {
-          // Move to next question
           const nextSession = await quizSessionManager.nextQuestion(message.channelId);
-          if (nextSession && nextSession.currentCard) {
-            response += `\n---\n\n`;
-            response += `**Question ${nextSession.questionNumber}/${nextSession.totalQuestions}**\n`;
-            response += nextSession.currentCard.front;
-            if (nextSession.currentCard.hints.length > 0) {
-              response += `\n\n_💡 Hints available: ${nextSession.currentCard.hints.length}_`;
-            }
+          if (nextSession) {
+            await refreshLiveQuiz(message.channel, nextSession);
+          } else {
+            await postQuizSummary(message.channel, message.channelId);
           }
         }
-
-        if ('send' in message.channel) {
-          await message.channel.send(response);
-        }
-        return; // Don't process this message further
+        return;
       }
     }
 

--- a/packages/discord/src/services/daily-quiz-embed.ts
+++ b/packages/discord/src/services/daily-quiz-embed.ts
@@ -25,6 +25,8 @@ import {
   renderEmojiGrid,
   type DailyPlay,
   type DailyPuzzle,
+  type DeckPoll,
+  type DeckTally,
   type GuildQuizConfig,
   type LeaderboardScope,
   type ServerLeaderboardRow,
@@ -34,9 +36,11 @@ import type { FlashcardResponse } from './quiz-session-manager.js';
 export const DAILY_PREFIX = 'quiz:daily:';
 export const DAILY_MODAL_INPUT = 'answer';
 export const SCHEDULE_PREFIX = 'quiz:schedule:';
+export const VOTE_PREFIX = 'quiz:vote:';
 
 export type DailyAction = 'guess' | 'modal' | 'share' | 'replay';
 export type ScheduleAction = 'shuffle' | 'save' | 'cancel';
+export type VoteAction = 'cast' | 'close';
 
 export function dailyCustomId(action: DailyAction, date: string, deck: string): string {
   return `${DAILY_PREFIX}${action}:${date}:${deck || 'all'}`;
@@ -301,6 +305,128 @@ export function buildGuildConfigEmbed(
     )
     .setFooter({ text: 'Use /quiz config decks set ... to change' });
   return { embeds: [embed] };
+}
+
+// ---------------------------------------------------------------------------
+// Deck vote (group picks tomorrow's deck).
+// ---------------------------------------------------------------------------
+
+/**
+ * Encoded as `quiz:vote:cast:<pollId>:<deck>` and `quiz:vote:close:<pollId>`.
+ * pollId is the autoincrement id from daily_quiz_deck_polls so we don't have
+ * to plumb guild/date through every interaction.
+ */
+export function voteCustomId(action: VoteAction, pollId: number, deck?: string): string {
+  if (action === 'cast') {
+    return `${VOTE_PREFIX}cast:${pollId}:${deck === '' ? 'all' : deck}`;
+  }
+  return `${VOTE_PREFIX}close:${pollId}`;
+}
+
+export interface ParsedVoteId {
+  action: VoteAction;
+  pollId: number;
+  deck: string; // '' for the "all decks" sentinel; '' on close-action too
+}
+
+export function parseVoteCustomId(customId: string): ParsedVoteId | null {
+  if (!customId.startsWith(VOTE_PREFIX)) return null;
+  const rest = customId.slice(VOTE_PREFIX.length);
+  const parts = rest.split(':');
+  if (parts.length < 2) return null;
+  const action = parts[0];
+  const pollId = Number(parts[1]);
+  if (!Number.isFinite(pollId)) return null;
+  if (action === 'close') return { action: 'close', pollId, deck: '' };
+  if (action === 'cast' && parts.length >= 3) {
+    const deckRaw = parts.slice(2).join(':');
+    return { action: 'cast', pollId, deck: deckRaw === 'all' ? '' : deckRaw };
+  }
+  return null;
+}
+
+function deckButtonLabel(deck: string): string {
+  return deck === '' ? 'All Decks' : deck.replace(/_/g, ' ');
+}
+
+function renderTallyBar(votes: number, max: number): string {
+  if (max === 0) return '░░░░░░';
+  const filled = Math.round((votes / max) * 6);
+  return '█'.repeat(filled) + '░'.repeat(6 - filled);
+}
+
+/**
+ * Live vote embed (open) or final-tally embed (closed). The closed variant
+ * also reports the winning deck and that cards have been scheduled.
+ */
+export function buildDeckVoteMessage(
+  poll: DeckPoll,
+  tallies: DeckTally[],
+  options: { winningDeck?: string | null; scheduledOk?: boolean } = {}
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const isClosed = poll.status === 'closed';
+  const maxVotes = Math.max(0, ...tallies.map((t) => t.votes));
+  const totalVotes = tallies.reduce((sum, t) => sum + t.votes, 0);
+
+  const lines = tallies.map((t) => {
+    const bar = renderTallyBar(t.votes, maxVotes);
+    const label = deckButtonLabel(t.deck);
+    const marker = isClosed && t.deck === options.winningDeck ? '🏆 ' : '';
+    return `${marker}**${label}** ${bar} ${t.votes}`;
+  });
+
+  const description = [
+    isClosed
+      ? `🔒 Voting closed — picking tomorrow's deck.`
+      : `One vote each — change anytime. Admin can close when ready.`,
+    '',
+    ...lines,
+    '',
+    `_${totalVotes} vote${totalVotes === 1 ? '' : 's'} cast_`,
+  ].join('\n');
+
+  const embed = new EmbedBuilder()
+    .setColor(isClosed ? 0xfee75c : 0x5865f2)
+    .setTitle(`🗳️ Vote · Tomorrow's Deck · ${poll.targetDate}`)
+    .setDescription(description);
+
+  if (isClosed) {
+    if (options.winningDeck) {
+      embed.addFields({
+        name: '🏆 Winner',
+        value: `**${deckButtonLabel(options.winningDeck)}** — ${
+          options.scheduledOk
+            ? `cards scheduled for ${poll.targetDate}. Run \`/quiz daily\` tomorrow to play.`
+            : '⚠️ Could not fetch cards; admin may need to `/quiz schedule` manually.'
+        }`,
+      });
+    } else {
+      embed.addFields({
+        name: '🤷 No winner',
+        value: 'No votes were cast. Tomorrow\'s daily will be a random pull.',
+      });
+    }
+    return { embeds: [embed], components: [] };
+  }
+
+  // Open poll: render one row of deck buttons + a separate row with the
+  // Close button. Discord caps an action row at 5 components so we slice.
+  const buttons = tallies.slice(0, 5).map((t) =>
+    new ButtonBuilder()
+      .setCustomId(voteCustomId('cast', poll.id, t.deck))
+      .setLabel(deckButtonLabel(t.deck))
+      .setStyle(ButtonStyle.Primary)
+  );
+  const voteRow = new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons);
+  const closeRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(voteCustomId('close', poll.id))
+      .setLabel('Close vote')
+      .setEmoji('🔒')
+      .setStyle(ButtonStyle.Secondary)
+  );
+
+  return { embeds: [embed], components: [voteRow, closeRow] };
 }
 
 const SCOPE_LABEL: Record<LeaderboardScope, string> = {

--- a/packages/discord/src/services/daily-quiz-embed.ts
+++ b/packages/discord/src/services/daily-quiz-embed.ts
@@ -21,8 +21,10 @@ import {
   TextInputStyle,
 } from 'discord.js';
 import {
+  ACHIEVEMENTS,
   DAILY_QUESTION_COUNT,
   renderEmojiGrid,
+  type Achievement,
   type DailyPlay,
   type DailyPuzzle,
   type DeckPoll,
@@ -30,6 +32,7 @@ import {
   type GuildQuizConfig,
   type LeaderboardScope,
   type ServerLeaderboardRow,
+  type UserStats,
 } from './daily-quiz.js';
 import type { FlashcardResponse } from './quiz-session-manager.js';
 
@@ -427,6 +430,130 @@ export function buildDeckVoteMessage(
   );
 
   return { embeds: [embed], components: [voteRow, closeRow] };
+}
+
+// ---------------------------------------------------------------------------
+// Growth: shareable /quiz me profile, challenge callout, achievement unlock.
+// ---------------------------------------------------------------------------
+
+function scoreEmoji(score: number, total: number): string {
+  if (total === 0 || score === 0) return '🟥';
+  if (score === total) return '🟩';
+  return '🟨';
+}
+
+/**
+ * Public profile card — designed to be screenshottable and tweeted.
+ * Surfaces the metrics that compound into "I want to play this": streak,
+ * perfect days, total points, and the trailing 7-day grid.
+ */
+export function buildProfileMessage(
+  user: { id: string; username: string },
+  stats: UserStats,
+  earnedAchievements: Achievement[]
+): { embeds: EmbedBuilder[] } {
+  const winRate =
+    stats.totalPlays > 0
+      ? Math.round((stats.totalCorrect / (stats.totalPlays * DAILY_QUESTION_COUNT)) * 100)
+      : 0;
+  const recentGrid = stats.recentResults
+    .map((r) => scoreEmoji(r.score, r.total))
+    .join(' ');
+  const recentLine = recentGrid || '_No daily plays yet — run `/quiz daily` to start._';
+
+  const badgesField =
+    earnedAchievements.length > 0
+      ? earnedAchievements
+          .map((a) => `${a.emoji} **${a.label}** — _${a.description}_`)
+          .join('\n')
+      : '_No badges yet. Play a daily to earn your first._';
+
+  const headline =
+    stats.totalPlays === 0
+      ? 'No plays yet — share this command with the channel to get rolling.'
+      : `${stats.totalCorrect} lifetime points · ${winRate}% win rate`;
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`📈 ${user.username} · Daily Quiz Profile`)
+    .setDescription(headline)
+    .addFields(
+      { name: 'Current Streak', value: `🔥 **${stats.currentStreak}**`, inline: true },
+      { name: 'Best Streak', value: `🏔️ **${stats.bestStreak}**`, inline: true },
+      { name: 'Perfect Days', value: `⭐ **${stats.perfectDays}**`, inline: true },
+      { name: 'Days Played', value: `**${stats.totalPlays}**`, inline: true },
+      { name: 'Last 7 Days', value: recentLine, inline: false },
+      { name: 'Badges', value: badgesField, inline: false }
+    )
+    .setFooter({ text: `Play your own: /quiz daily · Compare: /quiz leaderboard` });
+
+  return { embeds: [embed] };
+}
+
+/**
+ * Public challenge callout. Tags the target user, optionally includes the
+ * caller's most recent score as a flex/baseline to beat.
+ */
+export function buildChallengeMessage(
+  caller: { id: string; username: string },
+  target: { id: string },
+  callerRecent: DailyPlay | null,
+  todayDate: string,
+  note?: string
+): { content: string; embeds: EmbedBuilder[] } {
+  const score = callerRecent
+    ? callerRecent.results.filter((o) => o === 'correct').length
+    : null;
+  const grid =
+    callerRecent !== null
+      ? renderEmojiGrid(callerRecent.results, DAILY_QUESTION_COUNT)
+      : null;
+
+  const lines: string[] = [];
+  if (score !== null) {
+    lines.push(`**${caller.username}** dropped **${score}/${DAILY_QUESTION_COUNT}**`);
+    if (grid) lines.push(grid);
+  } else {
+    lines.push(`**${caller.username}** wants to know if you've got it.`);
+  }
+  lines.push('');
+  lines.push(`Run \`/quiz daily\` to play today's puzzle.`);
+  if (note) {
+    lines.push('');
+    lines.push(`_"${note}"_`);
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0xed4245)
+    .setTitle(`🎯 Daily Quiz Challenge · ${todayDate}`)
+    .setDescription(lines.join('\n'));
+
+  return { content: `<@${target.id}> — you've been challenged by <@${caller.id}>`, embeds: [embed] };
+}
+
+/**
+ * Tiny celebration card auto-posted when a player just unlocked a badge.
+ * Mentions the player so other members see the social proof.
+ */
+export function buildAchievementUnlockMessage(
+  user: { id: string; username: string },
+  unlocked: Achievement[]
+): { content: string; embeds: EmbedBuilder[] } {
+  if (unlocked.length === 0) {
+    return { content: '', embeds: [] };
+  }
+  const header = unlocked.length === 1 ? 'Achievement unlocked!' : 'Achievements unlocked!';
+  const lines = unlocked
+    .map((a) => `${a.emoji} **${a.label}** — _${a.description}_`)
+    .join('\n');
+
+  const embed = new EmbedBuilder()
+    .setColor(0xfee75c)
+    .setTitle(`🎉 ${header}`)
+    .setDescription(lines)
+    .setFooter({ text: 'See your full profile: /quiz me' });
+
+  return { content: `<@${user.id}>`, embeds: [embed] };
 }
 
 const SCOPE_LABEL: Record<LeaderboardScope, string> = {

--- a/packages/discord/src/services/daily-quiz-embed.ts
+++ b/packages/discord/src/services/daily-quiz-embed.ts
@@ -25,6 +25,8 @@ import {
   renderEmojiGrid,
   type DailyPlay,
   type DailyPuzzle,
+  type LeaderboardScope,
+  type ServerLeaderboardRow,
 } from './daily-quiz.js';
 
 export const DAILY_PREFIX = 'quiz:daily:';
@@ -176,6 +178,45 @@ export function buildDailyShareMessage(
     .setDescription([`**${username}** — **${score}/${DAILY_QUESTION_COUNT}**`, grid].join('\n'))
     .setFooter({ text: 'Try it: /quiz daily' });
 
+  return { embeds: [embed] };
+}
+
+const SCOPE_LABEL: Record<LeaderboardScope, string> = {
+  today: "Today's Daily",
+  week: 'This Week',
+  alltime: 'All-Time',
+};
+
+/**
+ * Server leaderboard card. Mirrors the share grid's visual style and surfaces
+ * the three Wordle-style metrics: total correct, perfect days (Wordles),
+ * current streak.
+ */
+export function buildLeaderboardMessage(
+  rows: ServerLeaderboardRow[],
+  scope: LeaderboardScope,
+  guildName: string
+): { embeds: EmbedBuilder[] } {
+  const embed = new EmbedBuilder()
+    .setColor(0xfee75c)
+    .setTitle(`🏆 ${guildName} · Daily Quiz Leaderboard`)
+    .setFooter({ text: `${SCOPE_LABEL[scope]} · ranked by total correct, then perfect days` });
+
+  if (rows.length === 0) {
+    embed.setDescription(
+      '_No completed daily quizzes yet — be the first with `/quiz daily`!_'
+    );
+    return { embeds: [embed] };
+  }
+
+  const lines = rows.map((row, i) => {
+    const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : `${i + 1}.`;
+    const perfect = row.perfectDays > 0 ? ` · ⭐${row.perfectDays}` : '';
+    const streak = row.currentStreak >= 2 ? ` · 🔥${row.currentStreak}` : '';
+    return `${medal} <@${row.userId}> — **${row.totalCorrect}** pts across ${row.plays} day${row.plays === 1 ? '' : 's'}${perfect}${streak}`;
+  });
+
+  embed.setDescription(lines.join('\n'));
   return { embeds: [embed] };
 }
 

--- a/packages/discord/src/services/daily-quiz-embed.ts
+++ b/packages/discord/src/services/daily-quiz-embed.ts
@@ -1,0 +1,201 @@
+/**
+ * UI builders for the async daily quiz — solo Wordle-style game.
+ *
+ * Encoded customId scheme so we can route interactions without per-user state
+ * in memory:
+ *   quiz:daily:guess:<date>:<deck>    button → opens guess modal
+ *   quiz:daily:modal:<date>:<deck>    modal submit
+ *   quiz:daily:share:<date>:<deck>    button → posts public share card
+ *   quiz:daily:replay:<date>:<deck>   button (post-share) → no-op informational
+ *
+ * <deck> is the literal deck id or the string "all".
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  ModalBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from 'discord.js';
+import {
+  DAILY_QUESTION_COUNT,
+  renderEmojiGrid,
+  type DailyPlay,
+  type DailyPuzzle,
+} from './daily-quiz.js';
+
+export const DAILY_PREFIX = 'quiz:daily:';
+export const DAILY_MODAL_INPUT = 'answer';
+
+export type DailyAction = 'guess' | 'modal' | 'share' | 'replay';
+
+export function dailyCustomId(action: DailyAction, date: string, deck: string): string {
+  return `${DAILY_PREFIX}${action}:${date}:${deck || 'all'}`;
+}
+
+export interface ParsedDailyId {
+  action: DailyAction;
+  date: string;
+  deck: string; // "" means all decks
+}
+
+export function parseDailyCustomId(customId: string): ParsedDailyId | null {
+  if (!customId.startsWith(DAILY_PREFIX)) return null;
+  const rest = customId.slice(DAILY_PREFIX.length);
+  const parts = rest.split(':');
+  if (parts.length < 3) return null;
+  const [action, date, ...deckParts] = parts;
+  if (action !== 'guess' && action !== 'modal' && action !== 'share' && action !== 'replay') {
+    return null;
+  }
+  const deckRaw = deckParts.join(':');
+  return { action, date, deck: deckRaw === 'all' ? '' : deckRaw };
+}
+
+function deckLabel(deck: string): string {
+  return deck || 'All Decks';
+}
+
+/**
+ * Ephemeral embed shown while the user is mid-game. Re-rendered after each
+ * guess so the progress grid grows in place.
+ */
+export function buildDailyGameMessage(play: DailyPlay, puzzle: DailyPuzzle): {
+  embeds: EmbedBuilder[];
+  components: ActionRowBuilder<ButtonBuilder>[];
+} {
+  const grid = renderEmojiGrid(play.results, DAILY_QUESTION_COUNT);
+  const card = puzzle.cards[play.currentQuestion];
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`🎓 Daily Quiz · ${deckLabel(puzzle.deck)}`)
+    .setDescription(
+      [
+        grid,
+        `_Question ${Math.min(play.currentQuestion + 1, DAILY_QUESTION_COUNT)} of ${DAILY_QUESTION_COUNT} · ${play.date}_`,
+      ].join('\n')
+    );
+
+  if (card) {
+    embed.addFields({
+      name: `❓ Question ${play.currentQuestion + 1}`,
+      value: card.front.length > 1000 ? card.front.slice(0, 997) + '…' : card.front,
+    });
+    if (card.hints.length > 0) {
+      embed.setFooter({
+        text: `💡 ${card.hints.length} hint(s) — they'll show after you submit a guess`,
+      });
+    }
+  }
+
+  if (play.results.length > 0) {
+    const lastIdx = play.results.length - 1;
+    const lastCard = puzzle.cards[lastIdx];
+    if (lastCard) {
+      embed.addFields({
+        name: play.results[lastIdx] === 'correct' ? '✅ Last answer' : '❌ Last answer',
+        value: `You said: _${play.guesses[lastIdx] || '(empty)'}_\nCorrect: **${lastCard.back}**`,
+      });
+    }
+  }
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(dailyCustomId('guess', play.date, play.deck))
+      .setLabel('Guess')
+      .setEmoji('⌨️')
+      .setStyle(ButtonStyle.Primary)
+  );
+
+  return { embeds: [embed], components: [row] };
+}
+
+/**
+ * Ephemeral embed after the user finishes all questions. Offers a Share
+ * button — clicking it posts the public card.
+ */
+export function buildDailyResultMessage(
+  play: DailyPlay,
+  puzzle: DailyPuzzle,
+  username: string
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const grid = renderEmojiGrid(play.results, DAILY_QUESTION_COUNT);
+  const score = play.results.filter((o) => o === 'correct').length;
+
+  const embed = new EmbedBuilder()
+    .setColor(score === DAILY_QUESTION_COUNT ? 0x57f287 : 0xfee75c)
+    .setTitle(`🏁 Daily Quiz · ${deckLabel(puzzle.deck)} · ${play.date}`)
+    .setDescription([grid, `**${score} / ${DAILY_QUESTION_COUNT}** correct`].join('\n'))
+    .addFields({
+      name: '🔎 Answer key',
+      value: puzzle.cards
+        .map((card, i) => {
+          const mark = play.results[i] === 'correct' ? '🟩' : '🟥';
+          const yourGuess = play.guesses[i] || '(empty)';
+          return `${mark} **${card.back}** — _you said: ${yourGuess}_`;
+        })
+        .join('\n')
+        .slice(0, 1024),
+    })
+    .setFooter({
+      text: play.shared
+        ? `Shared by ${username}`
+        : `Tap Share to post your result in the channel`,
+    });
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(dailyCustomId('share', play.date, play.deck))
+      .setLabel(play.shared ? 'Shared ✓' : 'Share to channel')
+      .setEmoji(play.shared ? '✅' : '📣')
+      .setStyle(play.shared ? ButtonStyle.Secondary : ButtonStyle.Success)
+      .setDisabled(play.shared)
+  );
+
+  return { embeds: [embed], components: [row] };
+}
+
+/**
+ * Public share card — what everyone in the channel sees. Mirrors the
+ * Wordle "share your result" block.
+ */
+export function buildDailyShareMessage(
+  play: DailyPlay,
+  username: string
+): { embeds: EmbedBuilder[] } {
+  const grid = renderEmojiGrid(play.results, DAILY_QUESTION_COUNT);
+  const score = play.results.filter((o) => o === 'correct').length;
+
+  const embed = new EmbedBuilder()
+    .setColor(0xfee75c)
+    .setTitle(`🎓 Daily Quiz · ${play.deck || 'All Decks'} · ${play.date}`)
+    .setDescription([`**${username}** — **${score}/${DAILY_QUESTION_COUNT}**`, grid].join('\n'))
+    .setFooter({ text: 'Try it: /quiz daily' });
+
+  return { embeds: [embed] };
+}
+
+/**
+ * Modal that pops up when the user clicks Guess. Single text input, length
+ * capped so we don't accept a novel.
+ */
+export function buildGuessModal(date: string, deck: string, questionNumber: number): ModalBuilder {
+  const modal = new ModalBuilder()
+    .setCustomId(dailyCustomId('modal', date, deck))
+    .setTitle(`Daily Quiz · Question ${questionNumber}`);
+
+  const input = new TextInputBuilder()
+    .setCustomId(DAILY_MODAL_INPUT)
+    .setLabel('Your answer')
+    .setStyle(TextInputStyle.Short)
+    .setMinLength(1)
+    .setMaxLength(200)
+    .setRequired(true);
+
+  modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+  return modal;
+}

--- a/packages/discord/src/services/daily-quiz-embed.ts
+++ b/packages/discord/src/services/daily-quiz-embed.ts
@@ -25,14 +25,18 @@ import {
   renderEmojiGrid,
   type DailyPlay,
   type DailyPuzzle,
+  type GuildQuizConfig,
   type LeaderboardScope,
   type ServerLeaderboardRow,
 } from './daily-quiz.js';
+import type { FlashcardResponse } from './quiz-session-manager.js';
 
 export const DAILY_PREFIX = 'quiz:daily:';
 export const DAILY_MODAL_INPUT = 'answer';
+export const SCHEDULE_PREFIX = 'quiz:schedule:';
 
 export type DailyAction = 'guess' | 'modal' | 'share' | 'replay';
+export type ScheduleAction = 'shuffle' | 'save' | 'cancel';
 
 export function dailyCustomId(action: DailyAction, date: string, deck: string): string {
   return `${DAILY_PREFIX}${action}:${date}:${deck || 'all'}`;
@@ -178,6 +182,124 @@ export function buildDailyShareMessage(
     .setDescription([`**${username}** — **${score}/${DAILY_QUESTION_COUNT}**`, grid].join('\n'))
     .setFooter({ text: 'Try it: /quiz daily' });
 
+  return { embeds: [embed] };
+}
+
+export function scheduleCustomId(action: ScheduleAction, date: string, deck: string): string {
+  return `${SCHEDULE_PREFIX}${action}:${date}:${deck || 'all'}`;
+}
+
+export interface ParsedScheduleId {
+  action: ScheduleAction;
+  date: string;
+  deck: string;
+}
+
+export function parseScheduleCustomId(customId: string): ParsedScheduleId | null {
+  if (!customId.startsWith(SCHEDULE_PREFIX)) return null;
+  const rest = customId.slice(SCHEDULE_PREFIX.length);
+  const parts = rest.split(':');
+  if (parts.length < 3) return null;
+  const [action, date, ...deckParts] = parts;
+  if (action !== 'shuffle' && action !== 'save' && action !== 'cancel') return null;
+  const deckRaw = deckParts.join(':');
+  return { action, date, deck: deckRaw === 'all' ? '' : deckRaw };
+}
+
+/**
+ * Admin schedule-preview card. Shows the proposed 5 cards for tomorrow with
+ * Shuffle / Use these / Cancel buttons. Lives in an ephemeral message.
+ */
+export function buildScheduleDraftMessage(
+  date: string,
+  deck: string,
+  cards: FlashcardResponse[],
+  options: { saved?: boolean; cancelled?: boolean } = {}
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const status = options.saved
+    ? '✅ Saved as tomorrow\'s puzzle.'
+    : options.cancelled
+      ? '❌ Cancelled.'
+      : '🪄 Preview — these are the cards your members will see.';
+
+  const embed = new EmbedBuilder()
+    .setColor(options.saved ? 0x57f287 : options.cancelled ? 0xed4245 : 0x5865f2)
+    .setTitle(`🗓️ Schedule Daily Quiz · ${date} · ${deck || 'All Decks'}`)
+    .setDescription(status);
+
+  if (cards.length > 0) {
+    embed.addFields({
+      name: `Cards (${cards.length})`,
+      value: cards
+        .map((c, i) => {
+          const front = c.front.length > 80 ? c.front.slice(0, 77) + '…' : c.front;
+          return `**${i + 1}.** ${front}\n   → _${c.back}_`;
+        })
+        .join('\n'),
+    });
+  } else {
+    embed.addFields({
+      name: 'No cards',
+      value: '_The API didn\'t hand back any cards for this deck — try again._',
+    });
+  }
+
+  if (options.saved || options.cancelled) {
+    return { embeds: [embed], components: [] };
+  }
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(scheduleCustomId('shuffle', date, deck))
+      .setLabel('Shuffle')
+      .setEmoji('🔀')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(cards.length === 0),
+    new ButtonBuilder()
+      .setCustomId(scheduleCustomId('save', date, deck))
+      .setLabel('Use these')
+      .setEmoji('✅')
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(cards.length === 0),
+    new ButtonBuilder()
+      .setCustomId(scheduleCustomId('cancel', date, deck))
+      .setLabel('Cancel')
+      .setStyle(ButtonStyle.Danger)
+  );
+
+  return { embeds: [embed], components: [row] };
+}
+
+/**
+ * Per-server config readout. Shows allowed decks + default.
+ */
+export function buildGuildConfigEmbed(
+  config: GuildQuizConfig,
+  guildName: string
+): { embeds: EmbedBuilder[] } {
+  const allowed =
+    config.allowedDecks.length === 0
+      ? '_All decks (no restriction)_'
+      : config.allowedDecks
+          .map((d) => `• ${d === '' ? 'All Decks (Random)' : d}`)
+          .join('\n');
+
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`⚙️ Daily Quiz Config · ${guildName}`)
+    .addFields(
+      { name: 'Allowed Decks', value: allowed, inline: false },
+      {
+        name: 'Default Deck',
+        value: config.defaultDeck === null
+          ? '_None_'
+          : config.defaultDeck === ''
+            ? 'All Decks (Random)'
+            : config.defaultDeck,
+        inline: false,
+      }
+    )
+    .setFooter({ text: 'Use /quiz config decks set ... to change' });
   return { embeds: [embed] };
 }
 

--- a/packages/discord/src/services/daily-quiz.ts
+++ b/packages/discord/src/services/daily-quiz.ts
@@ -1,0 +1,347 @@
+/**
+ * Async daily quiz — Wordle-style. Same N flashcards for everyone today,
+ * each user plays solo on their own time, then opts to share an emoji grid
+ * in the channel.
+ *
+ * - Puzzle is cached in `daily_quiz_puzzles` so every player today gets the
+ *   same cards (first player triggers the fetch).
+ * - Per-user state lives in `daily_quiz_plays` — UNIQUE(user_id, date, deck)
+ *   enforces "one play per day per deck".
+ * - Results are stored as a JSON array of 'correct' | 'wrong' so we can render
+ *   the emoji grid at any point (in-progress preview or final share card).
+ */
+
+import { getSyncDb, logger } from '@coachartie/shared';
+import type { FlashcardResponse } from './quiz-session-manager.js';
+
+export const DAILY_QUESTION_COUNT = 5;
+const FLASHCARD_API_BASE = 'https://ejfox.com/api/flashcards';
+const MAX_FETCH_ATTEMPTS = 15;
+
+export type DailyOutcome = 'correct' | 'wrong';
+
+export interface DailyPuzzle {
+  date: string;
+  deck: string; // empty string = "all decks"
+  cards: FlashcardResponse[];
+}
+
+export interface DailyPlay {
+  userId: string;
+  username: string | null;
+  date: string;
+  deck: string;
+  currentQuestion: number;
+  results: DailyOutcome[];
+  guesses: string[];
+  completed: boolean;
+  shared: boolean;
+  startedAt: string;
+  completedAt: string | null;
+}
+
+let tablesInitialized = false;
+
+export function ensureDailyQuizTables(): void {
+  if (tablesInitialized) return;
+  const db = getSyncDb();
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS daily_quiz_puzzles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      date TEXT NOT NULL,
+      deck TEXT NOT NULL,
+      cards_json TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(date, deck)
+    )
+  `);
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS daily_quiz_plays (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id TEXT NOT NULL,
+      username TEXT,
+      date TEXT NOT NULL,
+      deck TEXT NOT NULL,
+      current_question INTEGER DEFAULT 0,
+      results TEXT NOT NULL DEFAULT '[]',
+      guesses TEXT NOT NULL DEFAULT '[]',
+      completed INTEGER NOT NULL DEFAULT 0,
+      shared INTEGER NOT NULL DEFAULT 0,
+      started_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      completed_at DATETIME,
+      UNIQUE(user_id, date, deck)
+    )
+  `);
+
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_daily_quiz_plays_date_deck ON daily_quiz_plays(date, deck)`
+  );
+
+  tablesInitialized = true;
+}
+
+/**
+ * "Today" in UTC, formatted YYYY-MM-DD. Everyone gets the same puzzle
+ * regardless of local time zone — same trade-off as the NYT Wordle.
+ */
+export function todayKey(now: Date = new Date()): string {
+  return now.toISOString().slice(0, 10);
+}
+
+/**
+ * Get today's puzzle for a deck, creating + caching it on first call.
+ */
+export async function getOrCreateDailyPuzzle(
+  date: string,
+  deck: string
+): Promise<DailyPuzzle | null> {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+
+  const existing = db.get<{ cards_json: string }>(
+    `SELECT cards_json FROM daily_quiz_puzzles WHERE date = ? AND deck = ?`,
+    [date, deck]
+  );
+  if (existing) {
+    try {
+      const cards = JSON.parse(existing.cards_json) as FlashcardResponse[];
+      return { date, deck, cards };
+    } catch (e) {
+      logger.warn('Daily puzzle JSON parse failed; refetching:', e);
+    }
+  }
+
+  // Fetch cards, dedupe by id, stop once we have DAILY_QUESTION_COUNT unique.
+  const seen = new Set<string>();
+  const cards: FlashcardResponse[] = [];
+  for (
+    let attempt = 0;
+    attempt < MAX_FETCH_ATTEMPTS && cards.length < DAILY_QUESTION_COUNT;
+    attempt++
+  ) {
+    try {
+      const url = deck
+        ? `${FLASHCARD_API_BASE}/random/${deck}`
+        : `${FLASHCARD_API_BASE}/random`;
+      const res = await fetch(url);
+      if (!res.ok) {
+        logger.warn(`Daily puzzle fetch returned ${res.status}`);
+        break;
+      }
+      const card = (await res.json()) as FlashcardResponse;
+      if (!seen.has(card.id)) {
+        seen.add(card.id);
+        cards.push(card);
+      }
+    } catch (e) {
+      logger.warn('Daily puzzle fetch failed:', e);
+    }
+  }
+
+  if (cards.length === 0) return null;
+
+  db.run(
+    `INSERT OR IGNORE INTO daily_quiz_puzzles (date, deck, cards_json) VALUES (?, ?, ?)`,
+    [date, deck, JSON.stringify(cards)]
+  );
+
+  // Re-read in case a concurrent insert won the race — keeps everyone on the
+  // same cards.
+  const row = db.get<{ cards_json: string }>(
+    `SELECT cards_json FROM daily_quiz_puzzles WHERE date = ? AND deck = ?`,
+    [date, deck]
+  );
+  if (row) {
+    return { date, deck, cards: JSON.parse(row.cards_json) as FlashcardResponse[] };
+  }
+  return { date, deck, cards };
+}
+
+export function getUserPlay(
+  userId: string,
+  date: string,
+  deck: string
+): DailyPlay | null {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const row = db.get<{
+    user_id: string;
+    username: string | null;
+    date: string;
+    deck: string;
+    current_question: number;
+    results: string;
+    guesses: string;
+    completed: number;
+    shared: number;
+    started_at: string;
+    completed_at: string | null;
+  }>(
+    `SELECT user_id, username, date, deck, current_question, results, guesses,
+            completed, shared, started_at, completed_at
+       FROM daily_quiz_plays
+      WHERE user_id = ? AND date = ? AND deck = ?`,
+    [userId, date, deck]
+  );
+  if (!row) return null;
+
+  return {
+    userId: row.user_id,
+    username: row.username,
+    date: row.date,
+    deck: row.deck,
+    currentQuestion: row.current_question,
+    results: safeJsonArray<DailyOutcome>(row.results),
+    guesses: safeJsonArray<string>(row.guesses),
+    completed: row.completed === 1,
+    shared: row.shared === 1,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+  };
+}
+
+export function startUserPlay(
+  userId: string,
+  username: string,
+  date: string,
+  deck: string
+): DailyPlay {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  db.run(
+    `INSERT OR IGNORE INTO daily_quiz_plays
+       (user_id, username, date, deck, current_question, results, guesses, completed, shared)
+       VALUES (?, ?, ?, ?, 0, '[]', '[]', 0, 0)`,
+    [userId, username, date, deck]
+  );
+  const play = getUserPlay(userId, date, deck);
+  if (!play) {
+    throw new Error('Failed to start daily quiz play');
+  }
+  return play;
+}
+
+export function recordGuess(
+  userId: string,
+  date: string,
+  deck: string,
+  guess: string,
+  isCorrect: boolean
+): DailyPlay | null {
+  const play = getUserPlay(userId, date, deck);
+  if (!play || play.completed) return play;
+
+  const results = [...play.results, isCorrect ? 'correct' : 'wrong'] as DailyOutcome[];
+  const guesses = [...play.guesses, guess];
+  const nextIndex = play.currentQuestion + 1;
+
+  const db = getSyncDb();
+  db.run(
+    `UPDATE daily_quiz_plays
+        SET results = ?, guesses = ?, current_question = ?
+      WHERE user_id = ? AND date = ? AND deck = ?`,
+    [JSON.stringify(results), JSON.stringify(guesses), nextIndex, userId, date, deck]
+  );
+  return getUserPlay(userId, date, deck);
+}
+
+export function markCompleted(userId: string, date: string, deck: string): DailyPlay | null {
+  const db = getSyncDb();
+  db.run(
+    `UPDATE daily_quiz_plays
+        SET completed = 1, completed_at = CURRENT_TIMESTAMP
+      WHERE user_id = ? AND date = ? AND deck = ?`,
+    [userId, date, deck]
+  );
+  return getUserPlay(userId, date, deck);
+}
+
+export function markShared(userId: string, date: string, deck: string): void {
+  const db = getSyncDb();
+  db.run(
+    `UPDATE daily_quiz_plays
+        SET shared = 1
+      WHERE user_id = ? AND date = ? AND deck = ?`,
+    [userId, date, deck]
+  );
+}
+
+/**
+ * Daily leaderboard for one (date, deck) pairing, sorted by score then time.
+ */
+export interface DailyLeaderboardRow {
+  userId: string;
+  username: string | null;
+  score: number;
+  total: number;
+  completedAt: string | null;
+}
+
+export function getDailyLeaderboard(
+  date: string,
+  deck: string,
+  limit = 10
+): DailyLeaderboardRow[] {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const rows = db.all<{
+    user_id: string;
+    username: string | null;
+    results: string;
+    completed_at: string | null;
+  }>(
+    `SELECT user_id, username, results, completed_at
+       FROM daily_quiz_plays
+      WHERE date = ? AND deck = ? AND completed = 1
+      ORDER BY completed_at ASC
+      LIMIT ?`,
+    [date, deck, limit]
+  );
+
+  const leaderboard = rows.map((r) => {
+    const results = safeJsonArray<DailyOutcome>(r.results);
+    const score = results.filter((o) => o === 'correct').length;
+    return {
+      userId: r.user_id,
+      username: r.username,
+      score,
+      total: results.length,
+      completedAt: r.completed_at,
+    };
+  });
+
+  leaderboard.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    if (!a.completedAt) return 1;
+    if (!b.completedAt) return -1;
+    return a.completedAt.localeCompare(b.completedAt);
+  });
+  return leaderboard;
+}
+
+/**
+ * Render the Wordle-style emoji grid for a results array, padding remaining
+ * slots with ⬜ so the row is always DAILY_QUESTION_COUNT wide.
+ */
+export function renderEmojiGrid(results: DailyOutcome[], total: number): string {
+  const cells: string[] = [];
+  for (let i = 0; i < total; i++) {
+    if (i < results.length) {
+      cells.push(results[i] === 'correct' ? '🟩' : '🟥');
+    } else {
+      cells.push('⬜');
+    }
+  }
+  return cells.join(' ');
+}
+
+function safeJsonArray<T>(raw: string): T[] {
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}

--- a/packages/discord/src/services/daily-quiz.ts
+++ b/packages/discord/src/services/daily-quiz.ts
@@ -47,14 +47,40 @@ export function ensureDailyQuizTables(): void {
   if (tablesInitialized) return;
   const db = getSyncDb();
 
+  // The legacy puzzle table had UNIQUE(date, deck), which blocks per-guild
+  // scheduling. If we detect the legacy schema (no guild_id column), rebuild
+  // the table — it's only a fetch cache, so dropping it is safe.
+  const legacyCols = db.all<{ name: string }>(`PRAGMA table_info(daily_quiz_puzzles)`);
+  const hasGuildId = legacyCols.some((c) => c.name === 'guild_id');
+  if (legacyCols.length > 0 && !hasGuildId) {
+    db.exec(`DROP TABLE daily_quiz_puzzles`);
+  }
+
   db.exec(`
     CREATE TABLE IF NOT EXISTS daily_quiz_puzzles (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
+      guild_id TEXT,
       date TEXT NOT NULL,
       deck TEXT NOT NULL,
       cards_json TEXT NOT NULL,
+      scheduled_by TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+  // Per-guild uniqueness via expression index — NULL guild_id coalesces to ''
+  // so the global cache row coexists with per-guild rows for the same date+deck.
+  db.exec(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_daily_puzzles_scope
+       ON daily_quiz_puzzles(COALESCE(guild_id, ''), date, deck)`
+  );
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS daily_quiz_guild_config (
+      guild_id TEXT PRIMARY KEY,
+      allowed_decks TEXT NOT NULL DEFAULT '[]',
+      default_deck TEXT,
       created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-      UNIQUE(date, deck)
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
     )
   `);
 
@@ -102,36 +128,17 @@ export function todayKey(now: Date = new Date()): string {
 }
 
 /**
- * Get today's puzzle for a deck, creating + caching it on first call.
+ * Fetch up to `count` unique cards from the flashcard API for a deck.
+ * Deduped by card id. Used by both the on-demand puzzle creator and the
+ * admin scheduler preview.
  */
-export async function getOrCreateDailyPuzzle(
-  date: string,
-  deck: string
-): Promise<DailyPuzzle | null> {
-  ensureDailyQuizTables();
-  const db = getSyncDb();
-
-  const existing = db.get<{ cards_json: string }>(
-    `SELECT cards_json FROM daily_quiz_puzzles WHERE date = ? AND deck = ?`,
-    [date, deck]
-  );
-  if (existing) {
-    try {
-      const cards = JSON.parse(existing.cards_json) as FlashcardResponse[];
-      return { date, deck, cards };
-    } catch (e) {
-      logger.warn('Daily puzzle JSON parse failed; refetching:', e);
-    }
-  }
-
-  // Fetch cards, dedupe by id, stop once we have DAILY_QUESTION_COUNT unique.
+export async function fetchUniqueCards(
+  deck: string,
+  count: number = DAILY_QUESTION_COUNT
+): Promise<FlashcardResponse[]> {
   const seen = new Set<string>();
   const cards: FlashcardResponse[] = [];
-  for (
-    let attempt = 0;
-    attempt < MAX_FETCH_ATTEMPTS && cards.length < DAILY_QUESTION_COUNT;
-    attempt++
-  ) {
+  for (let attempt = 0; attempt < MAX_FETCH_ATTEMPTS && cards.length < count; attempt++) {
     try {
       const url = deck
         ? `${FLASHCARD_API_BASE}/random/${deck}`
@@ -150,24 +157,103 @@ export async function getOrCreateDailyPuzzle(
       logger.warn('Daily puzzle fetch failed:', e);
     }
   }
+  return cards;
+}
 
+/**
+ * Get today's puzzle for a (guild, deck), creating + caching it on first call.
+ * Falls back to a shared global puzzle (guild_id IS NULL) when a guild hasn't
+ * scheduled its own — keeps the original "one daily for everyone" mode
+ * working alongside the per-guild admin scheduler.
+ */
+export async function getOrCreateDailyPuzzle(
+  date: string,
+  deck: string,
+  guildId: string | null = null
+): Promise<DailyPuzzle | null> {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+
+  // Prefer a guild-scoped puzzle (admin scheduled or auto-cached), fall back
+  // to a global one if this guild hasn't cached anything yet.
+  const existing = db.get<{ cards_json: string }>(
+    `SELECT cards_json FROM daily_quiz_puzzles
+      WHERE date = ? AND deck = ?
+        AND (guild_id = ? OR (? IS NULL AND guild_id IS NULL))
+      ORDER BY (guild_id IS NULL) ASC
+      LIMIT 1`,
+    [date, deck, guildId, guildId]
+  );
+  if (existing) {
+    try {
+      const cards = JSON.parse(existing.cards_json) as FlashcardResponse[];
+      return { date, deck, cards };
+    } catch (e) {
+      logger.warn('Daily puzzle JSON parse failed; refetching:', e);
+    }
+  }
+
+  const cards = await fetchUniqueCards(deck, DAILY_QUESTION_COUNT);
   if (cards.length === 0) return null;
 
   db.run(
-    `INSERT OR IGNORE INTO daily_quiz_puzzles (date, deck, cards_json) VALUES (?, ?, ?)`,
-    [date, deck, JSON.stringify(cards)]
+    `INSERT OR IGNORE INTO daily_quiz_puzzles (guild_id, date, deck, cards_json) VALUES (?, ?, ?, ?)`,
+    [guildId, date, deck, JSON.stringify(cards)]
   );
 
   // Re-read in case a concurrent insert won the race — keeps everyone on the
   // same cards.
   const row = db.get<{ cards_json: string }>(
-    `SELECT cards_json FROM daily_quiz_puzzles WHERE date = ? AND deck = ?`,
-    [date, deck]
+    `SELECT cards_json FROM daily_quiz_puzzles
+      WHERE date = ? AND deck = ?
+        AND (guild_id = ? OR (? IS NULL AND guild_id IS NULL))
+      ORDER BY (guild_id IS NULL) ASC
+      LIMIT 1`,
+    [date, deck, guildId, guildId]
   );
   if (row) {
     return { date, deck, cards: JSON.parse(row.cards_json) as FlashcardResponse[] };
   }
   return { date, deck, cards };
+}
+
+/**
+ * Pre-create (or replace) tomorrow's puzzle for a specific guild. Used by
+ * the admin scheduler. Throws on collision-then-overwrite of an already
+ * played-against puzzle? We don't enforce that — admins overwriting an
+ * un-played future date is fine, and overwriting today's is allowed too
+ * (their call).
+ */
+export function scheduleDailyPuzzle(
+  date: string,
+  deck: string,
+  guildId: string,
+  cards: FlashcardResponse[],
+  scheduledBy: string
+): void {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const cardsJson = JSON.stringify(cards.slice(0, DAILY_QUESTION_COUNT));
+  // INSERT or UPDATE depending on existence — SQLite's UPSERT keeps it
+  // atomic against the unique index on (guild_id, date, deck).
+  db.run(
+    `INSERT INTO daily_quiz_puzzles (guild_id, date, deck, cards_json, scheduled_by)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(COALESCE(guild_id, ''), date, deck)
+     DO UPDATE SET cards_json = excluded.cards_json,
+                   scheduled_by = excluded.scheduled_by,
+                   created_at = CURRENT_TIMESTAMP`,
+    [guildId, date, deck, cardsJson, scheduledBy]
+  );
+}
+
+/**
+ * "Tomorrow" in UTC.
+ */
+export function tomorrowKey(now: Date = new Date()): string {
+  const next = new Date(now);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next.toISOString().slice(0, 10);
 }
 
 export function getUserPlay(
@@ -510,6 +596,84 @@ export function renderEmojiGrid(results: DailyOutcome[], total: number): string 
     }
   }
   return cells.join(' ');
+}
+
+/**
+ * The canonical deck list. The flashcard API exposes more, but these are the
+ * ones we surface in slash-command choices. `''` means "all decks (random)".
+ */
+export const KNOWN_DECKS = [
+  '',
+  'COMPUTERS',
+  'ELECTRICAL_AND_RADIO',
+  'POLITICS',
+  'RUBIKS_2x2',
+  'SAR_AND_WILDERNESS',
+] as const;
+
+export interface GuildQuizConfig {
+  guildId: string;
+  allowedDecks: string[]; // empty array = all known decks allowed
+  defaultDeck: string | null;
+}
+
+export function getGuildConfig(guildId: string): GuildQuizConfig {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const row = db.get<{ guild_id: string; allowed_decks: string; default_deck: string | null }>(
+    `SELECT guild_id, allowed_decks, default_deck FROM daily_quiz_guild_config WHERE guild_id = ?`,
+    [guildId]
+  );
+  if (!row) {
+    return { guildId, allowedDecks: [], defaultDeck: null };
+  }
+  return {
+    guildId: row.guild_id,
+    allowedDecks: safeJsonArray<string>(row.allowed_decks),
+    defaultDeck: row.default_deck,
+  };
+}
+
+export function setGuildAllowedDecks(guildId: string, decks: string[]): GuildQuizConfig {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  // De-dupe + normalize (treat null/undefined as 'all' sentinel)
+  const normalized = [...new Set(decks)].filter((d) => KNOWN_DECKS.includes(d as any));
+  db.run(
+    `INSERT INTO daily_quiz_guild_config (guild_id, allowed_decks, default_deck)
+       VALUES (?, ?, NULL)
+       ON CONFLICT(guild_id) DO UPDATE SET
+         allowed_decks = excluded.allowed_decks,
+         updated_at = CURRENT_TIMESTAMP`,
+    [guildId, JSON.stringify(normalized)]
+  );
+  return getGuildConfig(guildId);
+}
+
+export function setGuildDefaultDeck(guildId: string, deck: string | null): GuildQuizConfig {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const normalized = deck && KNOWN_DECKS.includes(deck as any) ? deck : null;
+  db.run(
+    `INSERT INTO daily_quiz_guild_config (guild_id, allowed_decks, default_deck)
+       VALUES (?, '[]', ?)
+       ON CONFLICT(guild_id) DO UPDATE SET
+         default_deck = excluded.default_deck,
+         updated_at = CURRENT_TIMESTAMP`,
+    [guildId, normalized]
+  );
+  return getGuildConfig(guildId);
+}
+
+/**
+ * Is this deck allowed in this guild? An empty allowed list (or no config row)
+ * means "no restriction — anything goes" so the feature defaults to open.
+ */
+export function isDeckAllowedForGuild(guildId: string | null, deck: string): boolean {
+  if (!guildId) return true;
+  const config = getGuildConfig(guildId);
+  if (config.allowedDecks.length === 0) return true;
+  return config.allowedDecks.includes(deck);
 }
 
 function safeJsonArray<T>(raw: string): T[] {

--- a/packages/discord/src/services/daily-quiz.ts
+++ b/packages/discord/src/services/daily-quiz.ts
@@ -116,6 +116,35 @@ export function ensureDailyQuizTables(): void {
     `CREATE INDEX IF NOT EXISTS idx_daily_quiz_plays_guild_user ON daily_quiz_plays(guild_id, user_id)`
   );
 
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS daily_quiz_deck_polls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      guild_id TEXT NOT NULL,
+      target_date TEXT NOT NULL,
+      channel_id TEXT,
+      message_id TEXT,
+      status TEXT NOT NULL DEFAULT 'open',
+      winning_deck TEXT,
+      created_by TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      closed_at DATETIME,
+      UNIQUE(guild_id, target_date)
+    )
+  `);
+  db.exec(
+    `CREATE TABLE IF NOT EXISTS daily_quiz_deck_votes (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      poll_id INTEGER NOT NULL,
+      user_id TEXT NOT NULL,
+      deck TEXT NOT NULL,
+      cast_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(poll_id, user_id)
+    )`
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_daily_quiz_deck_votes_poll ON daily_quiz_deck_votes(poll_id)`
+  );
+
   tablesInitialized = true;
 }
 
@@ -674,6 +703,170 @@ export function isDeckAllowedForGuild(guildId: string | null, deck: string): boo
   const config = getGuildConfig(guildId);
   if (config.allowedDecks.length === 0) return true;
   return config.allowedDecks.includes(deck);
+}
+
+// ---------------------------------------------------------------------------
+// Deck votes: group-decided deck for tomorrow's daily puzzle.
+// ---------------------------------------------------------------------------
+
+export type PollStatus = 'open' | 'closed';
+
+export interface DeckPoll {
+  id: number;
+  guildId: string;
+  targetDate: string;
+  channelId: string | null;
+  messageId: string | null;
+  status: PollStatus;
+  winningDeck: string | null;
+  createdBy: string | null;
+  createdAt: string;
+  closedAt: string | null;
+}
+
+export interface DeckTally {
+  deck: string;
+  votes: number;
+}
+
+function rowToPoll(row: any): DeckPoll {
+  return {
+    id: row.id,
+    guildId: row.guild_id,
+    targetDate: row.target_date,
+    channelId: row.channel_id,
+    messageId: row.message_id,
+    status: row.status,
+    winningDeck: row.winning_deck,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+    closedAt: row.closed_at,
+  };
+}
+
+/**
+ * Open a deck poll for (guildId, targetDate) if none exists yet. Returns
+ * the poll either way.
+ */
+export function getOrCreateDeckPoll(
+  guildId: string,
+  targetDate: string,
+  createdBy: string
+): DeckPoll {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  db.run(
+    `INSERT OR IGNORE INTO daily_quiz_deck_polls
+       (guild_id, target_date, status, created_by)
+       VALUES (?, ?, 'open', ?)`,
+    [guildId, targetDate, createdBy]
+  );
+  const row = db.get<any>(
+    `SELECT * FROM daily_quiz_deck_polls WHERE guild_id = ? AND target_date = ?`,
+    [guildId, targetDate]
+  );
+  if (!row) throw new Error('Failed to create deck poll');
+  return rowToPoll(row);
+}
+
+export function getDeckPoll(guildId: string, targetDate: string): DeckPoll | null {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const row = db.get<any>(
+    `SELECT * FROM daily_quiz_deck_polls WHERE guild_id = ? AND target_date = ?`,
+    [guildId, targetDate]
+  );
+  return row ? rowToPoll(row) : null;
+}
+
+export function getDeckPollById(pollId: number): DeckPoll | null {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const row = db.get<any>(`SELECT * FROM daily_quiz_deck_polls WHERE id = ?`, [pollId]);
+  return row ? rowToPoll(row) : null;
+}
+
+/**
+ * Record where the public poll embed lives so we can refresh it from
+ * button handlers without keeping a per-poll in-memory reference.
+ */
+export function attachPollMessage(pollId: number, channelId: string, messageId: string): void {
+  const db = getSyncDb();
+  db.run(
+    `UPDATE daily_quiz_deck_polls SET channel_id = ?, message_id = ? WHERE id = ?`,
+    [channelId, messageId, pollId]
+  );
+}
+
+/**
+ * Cast (or change) a user's vote in an open poll. No-op if the poll is closed.
+ */
+export function castDeckVote(pollId: number, userId: string, deck: string): void {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const poll = getDeckPollById(pollId);
+  if (!poll || poll.status !== 'open') return;
+  db.run(
+    `INSERT INTO daily_quiz_deck_votes (poll_id, user_id, deck)
+       VALUES (?, ?, ?)
+       ON CONFLICT(poll_id, user_id) DO UPDATE SET deck = excluded.deck, cast_at = CURRENT_TIMESTAMP`,
+    [pollId, userId, deck]
+  );
+}
+
+/**
+ * Tallies for a poll, preserving the order of `choices`. Decks with no votes
+ * still appear (zeroed) so the embed bars line up.
+ */
+export function getDeckVoteTallies(pollId: number, choices: string[]): DeckTally[] {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const rows = db.all<{ deck: string; votes: number }>(
+    `SELECT deck, COUNT(*) AS votes
+       FROM daily_quiz_deck_votes
+      WHERE poll_id = ?
+      GROUP BY deck`,
+    [pollId]
+  );
+  const map = new Map(rows.map((r) => [r.deck, r.votes]));
+  return choices.map((d) => ({ deck: d, votes: map.get(d) ?? 0 }));
+}
+
+/**
+ * Pick the winner from a tally array. Highest vote count wins; ties break by
+ * the order the deck appears in `choices` (deterministic, matches the
+ * button order so the leftmost option wins ties).
+ */
+export function pickWinningDeck(tallies: DeckTally[]): string | null {
+  const max = Math.max(0, ...tallies.map((t) => t.votes));
+  if (max === 0) return null;
+  return tallies.find((t) => t.votes === max)?.deck ?? null;
+}
+
+export interface CloseDeckPollResult {
+  winningDeck: string | null;
+  tallies: DeckTally[];
+}
+
+/**
+ * Close a poll and stamp the winning deck. Does NOT fetch cards / schedule
+ * — that's the caller's job (so it can pass the result through fetchUniqueCards
+ * + scheduleDailyPuzzle).
+ */
+export function closeDeckPoll(pollId: number, choices: string[]): CloseDeckPollResult {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const tallies = getDeckVoteTallies(pollId, choices);
+  const winner = pickWinningDeck(tallies);
+  db.run(
+    `UPDATE daily_quiz_deck_polls
+        SET status = 'closed',
+            winning_deck = ?,
+            closed_at = CURRENT_TIMESTAMP
+      WHERE id = ?`,
+    [winner, pollId]
+  );
+  return { winningDeck: winner, tallies };
 }
 
 function safeJsonArray<T>(raw: string): T[] {

--- a/packages/discord/src/services/daily-quiz.ts
+++ b/packages/discord/src/services/daily-quiz.ts
@@ -29,6 +29,7 @@ export interface DailyPuzzle {
 export interface DailyPlay {
   userId: string;
   username: string | null;
+  guildId: string | null;
   date: string;
   deck: string;
   currentQuestion: number;
@@ -62,6 +63,7 @@ export function ensureDailyQuizTables(): void {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       user_id TEXT NOT NULL,
       username TEXT,
+      guild_id TEXT,
       date TEXT NOT NULL,
       deck TEXT NOT NULL,
       current_question INTEGER DEFAULT 0,
@@ -75,8 +77,17 @@ export function ensureDailyQuizTables(): void {
     )
   `);
 
+  // Migration: add guild_id to existing databases predating server leaderboards.
+  const cols = db.all<{ name: string }>(`PRAGMA table_info(daily_quiz_plays)`);
+  if (!cols.some((c) => c.name === 'guild_id')) {
+    db.exec(`ALTER TABLE daily_quiz_plays ADD COLUMN guild_id TEXT`);
+  }
+
   db.exec(
     `CREATE INDEX IF NOT EXISTS idx_daily_quiz_plays_date_deck ON daily_quiz_plays(date, deck)`
+  );
+  db.exec(
+    `CREATE INDEX IF NOT EXISTS idx_daily_quiz_plays_guild_user ON daily_quiz_plays(guild_id, user_id)`
   );
 
   tablesInitialized = true;
@@ -169,6 +180,7 @@ export function getUserPlay(
   const row = db.get<{
     user_id: string;
     username: string | null;
+    guild_id: string | null;
     date: string;
     deck: string;
     current_question: number;
@@ -179,7 +191,7 @@ export function getUserPlay(
     started_at: string;
     completed_at: string | null;
   }>(
-    `SELECT user_id, username, date, deck, current_question, results, guesses,
+    `SELECT user_id, username, guild_id, date, deck, current_question, results, guesses,
             completed, shared, started_at, completed_at
        FROM daily_quiz_plays
       WHERE user_id = ? AND date = ? AND deck = ?`,
@@ -190,6 +202,7 @@ export function getUserPlay(
   return {
     userId: row.user_id,
     username: row.username,
+    guildId: row.guild_id,
     date: row.date,
     deck: row.deck,
     currentQuestion: row.current_question,
@@ -206,16 +219,27 @@ export function startUserPlay(
   userId: string,
   username: string,
   date: string,
-  deck: string
+  deck: string,
+  guildId: string | null = null
 ): DailyPlay {
   ensureDailyQuizTables();
   const db = getSyncDb();
   db.run(
     `INSERT OR IGNORE INTO daily_quiz_plays
-       (user_id, username, date, deck, current_question, results, guesses, completed, shared)
-       VALUES (?, ?, ?, ?, 0, '[]', '[]', 0, 0)`,
-    [userId, username, date, deck]
+       (user_id, username, guild_id, date, deck, current_question, results, guesses, completed, shared)
+       VALUES (?, ?, ?, ?, ?, 0, '[]', '[]', 0, 0)`,
+    [userId, username, guildId, date, deck]
   );
+  // If the row already existed without a guild_id (older client), patch it
+  // so this play counts toward the right server leaderboard.
+  if (guildId) {
+    db.run(
+      `UPDATE daily_quiz_plays
+          SET guild_id = COALESCE(guild_id, ?)
+        WHERE user_id = ? AND date = ? AND deck = ?`,
+      [guildId, userId, date, deck]
+    );
+  }
   const play = getUserPlay(userId, date, deck);
   if (!play) {
     throw new Error('Failed to start daily quiz play');
@@ -319,6 +343,157 @@ export function getDailyLeaderboard(
     return a.completedAt.localeCompare(b.completedAt);
   });
   return leaderboard;
+}
+
+export type LeaderboardScope = 'today' | 'week' | 'alltime';
+
+export interface ServerLeaderboardRow {
+  userId: string;
+  username: string | null;
+  plays: number; // completed plays in scope
+  totalCorrect: number; // sum of correct answers
+  perfectDays: number; // plays where score == DAILY_QUESTION_COUNT
+  currentStreak: number; // consecutive recent days with a completed play
+  bestStreak: number; // longest run of consecutive completed days
+}
+
+/**
+ * Server-scoped leaderboard. Aggregates every user's completed daily plays
+ * inside one guild, returning rankings by total-correct (primary) then
+ * perfect-days (tie-break) then plays. Streaks are computed over completed
+ * plays regardless of scope so "current streak" survives the daily reset.
+ */
+export function getServerLeaderboard(
+  guildId: string,
+  scope: LeaderboardScope = 'alltime',
+  limit = 10
+): ServerLeaderboardRow[] {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const today = todayKey();
+
+  const where: string[] = ['guild_id = ?', 'completed = 1'];
+  const params: (string | number)[] = [guildId];
+
+  if (scope === 'today') {
+    where.push('date = ?');
+    params.push(today);
+  } else if (scope === 'week') {
+    // Last 7 calendar days inclusive. ISO date strings sort lexically.
+    const weekAgo = new Date(`${today}T00:00:00Z`);
+    weekAgo.setUTCDate(weekAgo.getUTCDate() - 6);
+    where.push('date >= ?');
+    params.push(weekAgo.toISOString().slice(0, 10));
+  }
+
+  const rows = db.all<{
+    user_id: string;
+    username: string | null;
+    date: string;
+    results: string;
+  }>(
+    `SELECT user_id, username, date, results
+       FROM daily_quiz_plays
+      WHERE ${where.join(' AND ')}
+      ORDER BY user_id, date ASC`,
+    params
+  );
+
+  // Roll up per user.
+  const perUser = new Map<
+    string,
+    {
+      username: string | null;
+      plays: number;
+      totalCorrect: number;
+      perfectDays: number;
+      dates: string[];
+    }
+  >();
+  for (const row of rows) {
+    const results = safeJsonArray<DailyOutcome>(row.results);
+    const score = results.filter((o) => o === 'correct').length;
+    const bucket =
+      perUser.get(row.user_id) ??
+      { username: row.username, plays: 0, totalCorrect: 0, perfectDays: 0, dates: [] };
+    bucket.plays += 1;
+    bucket.totalCorrect += score;
+    if (score === DAILY_QUESTION_COUNT) bucket.perfectDays += 1;
+    if (row.username) bucket.username = row.username;
+    bucket.dates.push(row.date);
+    perUser.set(row.user_id, bucket);
+  }
+
+  const out: ServerLeaderboardRow[] = [];
+  for (const [userId, bucket] of perUser) {
+    const { currentStreak, bestStreak } = computeDayStreaks(bucket.dates, today);
+    out.push({
+      userId,
+      username: bucket.username,
+      plays: bucket.plays,
+      totalCorrect: bucket.totalCorrect,
+      perfectDays: bucket.perfectDays,
+      currentStreak,
+      bestStreak,
+    });
+  }
+
+  out.sort((a, b) => {
+    if (b.totalCorrect !== a.totalCorrect) return b.totalCorrect - a.totalCorrect;
+    if (b.perfectDays !== a.perfectDays) return b.perfectDays - a.perfectDays;
+    if (b.plays !== a.plays) return b.plays - a.plays;
+    return b.currentStreak - a.currentStreak;
+  });
+
+  return out.slice(0, limit);
+}
+
+/**
+ * Given an ascending list of ISO dates a user completed the daily and
+ * "today" as the reference point, return their current and best streaks
+ * (consecutive calendar days, allowing today OR yesterday as the leading
+ * edge — Wordle-style "you haven't lost the streak yet").
+ */
+export function computeDayStreaks(
+  dates: string[],
+  today: string
+): { currentStreak: number; bestStreak: number } {
+  if (dates.length === 0) return { currentStreak: 0, bestStreak: 0 };
+  const unique = [...new Set(dates)].sort();
+
+  let bestStreak = 1;
+  let run = 1;
+  for (let i = 1; i < unique.length; i++) {
+    if (consecutive(unique[i - 1], unique[i])) {
+      run += 1;
+      if (run > bestStreak) bestStreak = run;
+    } else {
+      run = 1;
+    }
+  }
+
+  // Current streak: walk backwards from today; allow yesterday as the most
+  // recent date (today's daily may not have been played yet).
+  const last = unique[unique.length - 1];
+  let currentStreak = 0;
+  if (last === today || consecutive(last, today)) {
+    currentStreak = 1;
+    for (let i = unique.length - 2; i >= 0; i--) {
+      if (consecutive(unique[i], unique[i + 1])) {
+        currentStreak += 1;
+      } else {
+        break;
+      }
+    }
+  }
+
+  return { currentStreak, bestStreak };
+}
+
+function consecutive(a: string, b: string): boolean {
+  const da = new Date(`${a}T00:00:00Z`);
+  const db = new Date(`${b}T00:00:00Z`);
+  return db.getTime() - da.getTime() === 24 * 60 * 60 * 1000;
 }
 
 /**

--- a/packages/discord/src/services/daily-quiz.ts
+++ b/packages/discord/src/services/daily-quiz.ts
@@ -869,6 +869,199 @@ export function closeDeckPoll(pollId: number, choices: string[]): CloseDeckPollR
   return { winningDeck: winner, tallies };
 }
 
+// ---------------------------------------------------------------------------
+// Per-user stats + achievements (growth: profile cards, social-proof badges).
+// ---------------------------------------------------------------------------
+
+export interface UserStats {
+  userId: string;
+  guildId: string | null;
+  totalPlays: number;
+  totalCorrect: number;
+  perfectDays: number;
+  currentStreak: number;
+  bestStreak: number;
+  recentResults: { date: string; score: number; total: number }[]; // newest first
+}
+
+/**
+ * Compute aggregate stats for one user, scoped to a guild (or globally when
+ * guildId is null). All numbers come from completed plays only.
+ */
+export function computeUserStats(userId: string, guildId: string | null): UserStats {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const where = guildId ? 'user_id = ? AND guild_id = ? AND completed = 1' : 'user_id = ? AND completed = 1';
+  const params = guildId ? [userId, guildId] : [userId];
+
+  const rows = db.all<{ date: string; results: string }>(
+    `SELECT date, results FROM daily_quiz_plays
+       WHERE ${where}
+       ORDER BY date ASC`,
+    params
+  );
+
+  let totalCorrect = 0;
+  let perfectDays = 0;
+  const dates: string[] = [];
+  for (const row of rows) {
+    const r = safeJsonArray<DailyOutcome>(row.results);
+    const score = r.filter((o) => o === 'correct').length;
+    totalCorrect += score;
+    if (score === DAILY_QUESTION_COUNT) perfectDays += 1;
+    dates.push(row.date);
+  }
+
+  const { currentStreak, bestStreak } = computeDayStreaks(dates, todayKey());
+
+  // Newest-first recent results (capped at 7 — enough for the profile grid).
+  const recentRows = [...rows].reverse().slice(0, 7);
+  const recentResults = recentRows.map((row) => {
+    const r = safeJsonArray<DailyOutcome>(row.results);
+    return { date: row.date, score: r.filter((o) => o === 'correct').length, total: r.length };
+  });
+
+  return {
+    userId,
+    guildId,
+    totalPlays: rows.length,
+    totalCorrect,
+    perfectDays,
+    currentStreak,
+    bestStreak,
+    recentResults,
+  };
+}
+
+/**
+ * Look up a user's most recent completed play (any deck) — used by the
+ * /quiz challenge callout so we can flex their score at the target.
+ */
+export function getMostRecentCompletedPlay(
+  userId: string,
+  guildId: string | null,
+  onOrAfter?: string
+): DailyPlay | null {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  const conditions: string[] = ['user_id = ?', 'completed = 1'];
+  const params: (string | number)[] = [userId];
+  if (guildId) {
+    conditions.push('guild_id = ?');
+    params.push(guildId);
+  }
+  if (onOrAfter) {
+    conditions.push('date >= ?');
+    params.push(onOrAfter);
+  }
+  const row = db.get<any>(
+    `SELECT user_id, username, guild_id, date, deck, current_question, results, guesses,
+            completed, shared, started_at, completed_at
+       FROM daily_quiz_plays
+      WHERE ${conditions.join(' AND ')}
+      ORDER BY date DESC, completed_at DESC
+      LIMIT 1`,
+    params
+  );
+  if (!row) return null;
+  return {
+    userId: row.user_id,
+    username: row.username,
+    guildId: row.guild_id,
+    date: row.date,
+    deck: row.deck,
+    currentQuestion: row.current_question,
+    results: safeJsonArray<DailyOutcome>(row.results),
+    guesses: safeJsonArray<string>(row.guesses),
+    completed: row.completed === 1,
+    shared: row.shared === 1,
+    startedAt: row.started_at,
+    completedAt: row.completed_at,
+  };
+}
+
+export interface Achievement {
+  id: string;
+  emoji: string;
+  label: string;
+  description: string;
+  test: (stats: UserStats) => boolean;
+}
+
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: 'first_blood',
+    emoji: '🎯',
+    label: 'First Blood',
+    description: 'Completed your first daily quiz',
+    test: (s) => s.totalPlays >= 1,
+  },
+  {
+    id: 'perfect_1',
+    emoji: '⭐',
+    label: 'Perfect',
+    description: `Score ${DAILY_QUESTION_COUNT}/${DAILY_QUESTION_COUNT} on a daily`,
+    test: (s) => s.perfectDays >= 1,
+  },
+  {
+    id: 'streak_3',
+    emoji: '🔥',
+    label: 'On Fire',
+    description: '3-day streak',
+    test: (s) => s.bestStreak >= 3,
+  },
+  {
+    id: 'streak_7',
+    emoji: '💎',
+    label: 'Week Warrior',
+    description: '7-day streak',
+    test: (s) => s.bestStreak >= 7,
+  },
+  {
+    id: 'streak_30',
+    emoji: '👑',
+    label: 'Habitual',
+    description: '30-day streak',
+    test: (s) => s.bestStreak >= 30,
+  },
+  {
+    id: 'perfect_10',
+    emoji: '🌟',
+    label: 'Stellar',
+    description: '10 perfect days',
+    test: (s) => s.perfectDays >= 10,
+  },
+  {
+    id: 'points_25',
+    emoji: '🏅',
+    label: 'Quarter Century',
+    description: '25 lifetime points',
+    test: (s) => s.totalCorrect >= 25,
+  },
+  {
+    id: 'points_100',
+    emoji: '🏆',
+    label: 'Centurion',
+    description: '100 lifetime points',
+    test: (s) => s.totalCorrect >= 100,
+  },
+];
+
+export function computeAchievements(stats: UserStats): Set<string> {
+  return new Set(ACHIEVEMENTS.filter((a) => a.test(stats)).map((a) => a.id));
+}
+
+/**
+ * Achievements newly unlocked between two stat snapshots. Used for the
+ * "just unlocked" celebratory post that drops in channel after a user
+ * finishes their daily.
+ */
+export function diffAchievements(before: UserStats, after: UserStats): Achievement[] {
+  const beforeSet = computeAchievements(before);
+  const afterSet = computeAchievements(after);
+  return ACHIEVEMENTS.filter((a) => !beforeSet.has(a.id) && afterSet.has(a.id));
+}
+
 function safeJsonArray<T>(raw: string): T[] {
   try {
     const parsed = JSON.parse(raw);

--- a/packages/discord/src/services/quiz-embed.ts
+++ b/packages/discord/src/services/quiz-embed.ts
@@ -1,0 +1,191 @@
+/**
+ * Wordle-style embed + button builders for the quiz game.
+ *
+ * The quiz UX is a single embed that updates in place — progress bar, current
+ * question, scoreboard, and a row of action buttons (Hint / Skip / End).
+ * End-of-quiz replaces it with a shareable result card.
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+} from 'discord.js';
+import { renderProgressBar, type QuizSession } from './quiz-session-manager.js';
+
+export const QUIZ_BUTTON_PREFIX = 'quiz:';
+
+export type QuizButtonAction = 'hint' | 'skip' | 'end' | 'again';
+
+export function quizButtonId(action: QuizButtonAction): string {
+  return `${QUIZ_BUTTON_PREFIX}${action}`;
+}
+
+export function parseQuizButtonId(customId: string): QuizButtonAction | null {
+  if (!customId.startsWith(QUIZ_BUTTON_PREFIX)) return null;
+  const action = customId.slice(QUIZ_BUTTON_PREFIX.length) as QuizButtonAction;
+  if (action === 'hint' || action === 'skip' || action === 'end' || action === 'again') {
+    return action;
+  }
+  return null;
+}
+
+/**
+ * Format the scoreboard as a stacked block (one user per line) — easier to
+ * read in a Wordle-style embed than the single-line " | " separator.
+ */
+function formatScoreboard(session: QuizSession): string {
+  if (session.scores.size === 0) {
+    return '_No scores yet — first correct answer wins the point!_';
+  }
+  const sorted = [...session.scores.entries()].sort((a, b) => b[1] - a[1]);
+  return sorted
+    .map(([userId, score], i) => {
+      const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '▫️';
+      const streak = session.streaks.get(userId) || 0;
+      const streakBadge = streak >= 2 ? ` · 🔥${streak}` : '';
+      return `${medal} <@${userId}> — **${score}**${streakBadge}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Build the live quiz embed + action row. Render this on /quiz start and on
+ * every state change (correct answer, skip, hint, timeout) so the host
+ * message can be edited in place.
+ */
+export function buildLiveQuizMessage(session: QuizSession): {
+  embeds: EmbedBuilder[];
+  components: ActionRowBuilder<ButtonBuilder>[];
+} {
+  const card = session.currentCard;
+  const progressBar = renderProgressBar(session.progress);
+  const deckLabel = session.deckId || 'All Decks';
+  const judgeLabel = session.aiJudge ? ' · 🤖 AI Judge' : '';
+
+  const embed = new EmbedBuilder()
+    .setColor(session.lastBanner?.startsWith('✅') ? 0x57f287 : 0x5865f2)
+    .setTitle(`🎮 Quiz · ${deckLabel}${judgeLabel}`)
+    .setDescription(
+      [
+        session.lastBanner ? `${session.lastBanner}\n` : null,
+        progressBar,
+        `_Question ${session.questionNumber} of ${session.totalQuestions}_`,
+      ]
+        .filter(Boolean)
+        .join('\n')
+    );
+
+  if (card) {
+    embed.addFields({
+      name: `❓ Question ${session.questionNumber}`,
+      value: card.front.length > 1000 ? card.front.slice(0, 997) + '…' : card.front,
+    });
+
+    if (session.hintsRevealed > 0) {
+      const revealed = card.hints.slice(0, session.hintsRevealed);
+      embed.addFields({
+        name: `💡 Hints (${session.hintsRevealed}/${card.hints.length})`,
+        value: revealed.map((h, i) => `${i + 1}. ${h}`).join('\n'),
+      });
+    } else if (card.hints.length > 0) {
+      embed.setFooter({ text: `💡 ${card.hints.length} hint(s) available — tap Hint` });
+    }
+  }
+
+  embed.addFields({
+    name: '📊 Scoreboard',
+    value: formatScoreboard(session),
+  });
+
+  const hintsLeft = card ? card.hints.length - session.hintsRevealed : 0;
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(quizButtonId('hint'))
+      .setLabel(`Hint${hintsLeft > 0 ? ` (${hintsLeft})` : ''}`)
+      .setEmoji('💡')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(hintsLeft <= 0 || session.answered),
+    new ButtonBuilder()
+      .setCustomId(quizButtonId('skip'))
+      .setLabel('Skip')
+      .setEmoji('⏭️')
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(session.answered),
+    new ButtonBuilder()
+      .setCustomId(quizButtonId('end'))
+      .setLabel('End Quiz')
+      .setEmoji('🛑')
+      .setStyle(ButtonStyle.Danger)
+  );
+
+  return { embeds: [embed], components: [row] };
+}
+
+/**
+ * Build the shareable end-of-quiz card — emoji result grid, winner, streak
+ * champion. Mirrors the Wordle "share my result" embed.
+ */
+export function buildQuizSummary(
+  session: QuizSession,
+  finalScores: Map<string, number>
+): { embeds: EmbedBuilder[]; components: ActionRowBuilder<ButtonBuilder>[] } {
+  const progressBar = renderProgressBar(session.progress);
+  const deckLabel = session.deckId || 'All Decks';
+
+  const correctCount = session.progress.filter((o) => o === 'correct').length;
+  const missedCount = session.progress.filter((o) => o === 'missed').length;
+
+  const lines: string[] = [progressBar, `_${correctCount} solved · ${missedCount} missed_`];
+
+  if (finalScores.size > 0) {
+    const sorted = [...finalScores.entries()].sort((a, b) => b[1] - a[1]);
+    const maxScore = sorted[0][1];
+    const winners = sorted.filter(([, s]) => s === maxScore).map(([uid]) => uid);
+    if (winners.length === 1) {
+      lines.push(`🏆 **Winner:** <@${winners[0]}> — ${maxScore} pts`);
+    } else {
+      lines.push(`🏆 **Tied:** ${winners.map((w) => `<@${w}>`).join(', ')} — ${maxScore} pts each`);
+    }
+  } else {
+    lines.push('_No one scored — better luck next time._');
+  }
+
+  const streakLeaders = [...session.bestStreaks.entries()]
+    .filter(([, s]) => s >= 2)
+    .sort((a, b) => b[1] - a[1]);
+  if (streakLeaders.length > 0) {
+    const [topUser, topStreak] = streakLeaders[0];
+    lines.push(`🔥 **Streak Champion:** <@${topUser}> — ${topStreak} in a row`);
+  }
+
+  const embed = new EmbedBuilder()
+    .setColor(0xfee75c)
+    .setTitle(`🏁 Quiz Complete · ${deckLabel}`)
+    .setDescription(lines.join('\n'));
+
+  if (finalScores.size > 0) {
+    const board = [...finalScores.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([uid, score], i) => {
+        const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '▫️';
+        const best = session.bestStreaks.get(uid) || 0;
+        const streakBadge = best >= 2 ? ` · 🔥${best}` : '';
+        return `${medal} <@${uid}> — **${score}**${streakBadge}`;
+      })
+      .join('\n');
+    embed.addFields({ name: '📊 Final Scoreboard', value: board });
+  }
+
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(quizButtonId('again'))
+      .setLabel('Play Again')
+      .setEmoji('🔁')
+      .setStyle(ButtonStyle.Primary)
+  );
+
+  return { embeds: [embed], components: [row] };
+}

--- a/packages/discord/src/services/quiz-session-manager.ts
+++ b/packages/discord/src/services/quiz-session-manager.ts
@@ -17,6 +17,8 @@ export interface FlashcardResponse {
   course: string;
 }
 
+export type QuestionOutcome = 'correct' | 'missed' | 'current' | 'upcoming';
+
 export interface QuizSession {
   channelId: string;
   deckId?: string;
@@ -36,6 +38,16 @@ export interface QuizSession {
   attemptedThisQuestion: Set<string>;
   // In-flight LLM judgements so we don't fire duplicate calls per user/question
   pendingJudgements: Set<string>;
+  // Hints revealed for the current question (count)
+  hintsRevealed: number;
+  // Per-question outcome for the progress bar
+  progress: QuestionOutcome[];
+  // Discord message id we update in place — Wordle-style single embed
+  questionMessageId?: string;
+  // Username cache so we can render mentions without re-fetching members
+  usernames: Map<string, string>;
+  // Last answer-result banner to render at the top of the embed
+  lastBanner?: string;
 }
 
 export interface QuizStartOptions {
@@ -171,6 +183,38 @@ Answer (yes/no):`;
 }
 
 /**
+ * Build the initial per-question outcome array — first slot is "current",
+ * the rest are "upcoming". Wordle-style empty squares until played.
+ */
+export function buildInitialProgress(total: number): QuestionOutcome[] {
+  const arr: QuestionOutcome[] = [];
+  for (let i = 0; i < total; i++) {
+    arr.push(i === 0 ? 'current' : 'upcoming');
+  }
+  return arr;
+}
+
+/**
+ * Render a Wordle-style emoji progress bar from a list of outcomes.
+ */
+export function renderProgressBar(progress: QuestionOutcome[]): string {
+  return progress
+    .map((o) => {
+      switch (o) {
+        case 'correct':
+          return '🟩';
+        case 'missed':
+          return '⬛';
+        case 'current':
+          return '🟨';
+        case 'upcoming':
+          return '⬜';
+      }
+    })
+    .join(' ');
+}
+
+/**
  * Fetch a random flashcard from the API
  */
 async function fetchRandomCard(deckId?: string): Promise<FlashcardResponse> {
@@ -230,6 +274,9 @@ export const quizSessionManager = {
       startedAt: new Date(),
       attemptedThisQuestion: new Set(),
       pendingJudgements: new Set(),
+      hintsRevealed: 0,
+      progress: buildInitialProgress(questionCount),
+      usernames: new Map(),
       onTimeout: onTimeout ? () => onTimeout(session) : undefined,
     };
 
@@ -367,6 +414,9 @@ export const quizSessionManager = {
       }
     }
 
+    // Mark this question correct in the Wordle-style progress bar
+    session.progress[session.questionNumber - 1] = 'correct';
+
     const quizEnded = session.questionNumber >= session.totalQuestions;
 
     logger.info(
@@ -412,6 +462,9 @@ export const quizSessionManager = {
     session.answered = false;
     session.attemptedThisQuestion = new Set();
     session.pendingJudgements = new Set();
+    session.hintsRevealed = 0;
+    // The slot we just moved into is now the current question
+    session.progress[session.questionNumber - 1] = 'current';
 
     // Set new timeout
     if (session.onTimeout) {
@@ -454,6 +507,7 @@ export const quizSessionManager = {
     for (const attemptedId of session.attemptedThisQuestion) {
       session.streaks.set(attemptedId, 0);
     }
+    session.progress[session.questionNumber - 1] = 'missed';
 
     // Move to next question or end
     const nextSession = await this.nextQuestion(channelId);
@@ -479,6 +533,7 @@ export const quizSessionManager = {
     for (const attemptedId of session.attemptedThisQuestion) {
       session.streaks.set(attemptedId, 0);
     }
+    session.progress[session.questionNumber - 1] = 'missed';
 
     // Move to next question
     const nextSession = await this.nextQuestion(channelId);
@@ -517,6 +572,47 @@ export const quizSessionManager = {
   getScores(channelId: string): Map<string, number> | null {
     const session = activeSessions.get(channelId);
     return session ? new Map(session.scores) : null;
+  },
+
+  /**
+   * Cache a userId → displayName mapping so we can render @-free names in
+   * shareable end cards without re-fetching members.
+   */
+  rememberUsername(channelId: string, userId: string, displayName: string): void {
+    const session = activeSessions.get(channelId);
+    if (!session) return;
+    session.usernames.set(userId, displayName);
+  },
+
+  /**
+   * Track which Discord message hosts the live quiz embed so callers can
+   * edit it in place.
+   */
+  setQuestionMessage(channelId: string, messageId: string): void {
+    const session = activeSessions.get(channelId);
+    if (session) session.questionMessageId = messageId;
+  },
+
+  /**
+   * Reveal the next available hint for the current question. Returns the hint
+   * text, or null if there are no more hints / no active question.
+   */
+  revealHint(channelId: string): string | null {
+    const session = activeSessions.get(channelId);
+    if (!session?.currentCard) return null;
+    const hints = session.currentCard.hints;
+    if (session.hintsRevealed >= hints.length) return null;
+    const hint = hints[session.hintsRevealed];
+    session.hintsRevealed++;
+    return hint;
+  },
+
+  /**
+   * Update the top banner that the embed renders (e.g. "✅ alice got it!").
+   */
+  setBanner(channelId: string, banner: string | undefined): void {
+    const session = activeSessions.get(channelId);
+    if (session) session.lastBanner = banner;
   },
 
   /**

--- a/packages/discord/src/services/quiz-session-manager.ts
+++ b/packages/discord/src/services/quiz-session-manager.ts
@@ -88,9 +88,10 @@ function normalizeAnswer(text: string): string {
 }
 
 /**
- * Check if user's answer matches the correct answer
+ * Check if user's answer matches the correct answer (fast string-based check).
+ * Exported so the daily-quiz flow can reuse the same matching rules.
  */
-function isCorrectAnswer(userAnswer: string, correctAnswer: string): boolean {
+export function isCorrectAnswer(userAnswer: string, correctAnswer: string): boolean {
   const userNorm = normalizeAnswer(userAnswer);
   const correctNorm = normalizeAnswer(correctAnswer);
 

--- a/packages/discord/src/services/quiz-session-manager.ts
+++ b/packages/discord/src/services/quiz-session-manager.ts
@@ -3,6 +3,9 @@ import { logger } from '@coachartie/shared';
 const FLASHCARD_API_BASE = 'https://ejfox.com/api/flashcards';
 const DEFAULT_QUESTION_COUNT = 10;
 const QUESTION_TIMEOUT_MS = 30000; // 30 seconds per question
+const AI_JUDGE_MODEL = process.env.QUIZ_JUDGE_MODEL || 'google/gemini-2.0-flash-001';
+const AI_JUDGE_URL =
+  process.env.QUIZ_JUDGE_URL || 'https://router.tools.ejfox.com/v1/chat/completions';
 
 export interface FlashcardResponse {
   id: string;
@@ -20,12 +23,19 @@ export interface QuizSession {
   currentCard: FlashcardResponse | null;
   questionNumber: number;
   totalQuestions: number;
-  scores: Map<string, number>; // oderId -> score
+  scores: Map<string, number>; // userId -> score
+  streaks: Map<string, number>; // userId -> current streak in this session
+  bestStreaks: Map<string, number>; // userId -> best streak in this session
   answered: boolean;
+  aiJudge: boolean; // Use LLM to grade fuzzy answers
   startedBy: string;
   startedAt: Date;
   questionTimeout?: ReturnType<typeof setTimeout>;
   onTimeout?: () => void; // Callback when question times out
+  // userIds who attempted this question (used to break streaks on miss)
+  attemptedThisQuestion: Set<string>;
+  // In-flight LLM judgements so we don't fire duplicate calls per user/question
+  pendingJudgements: Set<string>;
 }
 
 export interface QuizStartOptions {
@@ -33,6 +43,7 @@ export interface QuizStartOptions {
   userId: string;
   deckId?: string;
   questionCount?: number;
+  aiJudge?: boolean;
   onTimeout?: (session: QuizSession) => void;
 }
 
@@ -41,9 +52,13 @@ export interface AnswerResult {
   isFirstCorrect: boolean;
   correctAnswer: string;
   currentScores: Map<string, number>;
+  currentStreaks: Map<string, number>;
+  bestStreaks: Map<string, number>;
+  winnerStreak: number;
   questionNumber: number;
   totalQuestions: number;
   quizEnded: boolean;
+  judgedByAI: boolean;
 }
 
 // In-memory storage for active quiz sessions
@@ -83,6 +98,79 @@ function isCorrectAnswer(userAnswer: string, correctAnswer: string): boolean {
 }
 
 /**
+ * Heuristic: does a message look like a real answer attempt, vs. chatter?
+ * Used to gate LLM judgement so we don't burn tokens on every message.
+ */
+export function looksLikeAnswerAttempt(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  if (trimmed.length > 200) return false;
+  if (trimmed.startsWith('/') || trimmed.startsWith('!')) return false;
+  // Pure emoji/punctuation reactions
+  if (!/[a-z0-9]/i.test(trimmed)) return false;
+  return true;
+}
+
+/**
+ * Ask a light LLM whether a user's answer is semantically equivalent to the
+ * correct answer. Returns null if the call fails or the API key is missing.
+ */
+export async function verifyAnswerWithLLM(
+  question: string,
+  correctAnswer: string,
+  userAnswer: string
+): Promise<boolean | null> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    return null;
+  }
+
+  const prompt = `You are grading a flashcard quiz answer. Reply with ONLY "yes" or "no".
+
+Is the user's answer a correct/equivalent response to the question? Accept synonyms, abbreviations, and minor wording differences. Reject answers that are wrong, off-topic, or only tangentially related.
+
+Question: ${question}
+Correct answer: ${correctAnswer}
+User answer: ${userAnswer}
+
+Answer (yes/no):`;
+
+  try {
+    const response = await fetch(AI_JUDGE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'HTTP-Referer': 'https://coach-artie.local',
+        'X-Title': 'Coach Artie Quiz Judge',
+      },
+      body: JSON.stringify({
+        model: AI_JUDGE_MODEL,
+        messages: [{ role: 'user', content: prompt }],
+        max_tokens: 5,
+        temperature: 0,
+      }),
+    });
+
+    if (!response.ok) {
+      logger.warn(`Quiz LLM judge returned ${response.status}`);
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+    const raw = (data.choices?.[0]?.message?.content || '').toLowerCase().trim();
+    if (raw.startsWith('yes')) return true;
+    if (raw.startsWith('no')) return false;
+    return null;
+  } catch (e) {
+    logger.warn('Quiz LLM judge call failed:', e);
+    return null;
+  }
+}
+
+/**
  * Fetch a random flashcard from the API
  */
 async function fetchRandomCard(deckId?: string): Promise<FlashcardResponse> {
@@ -115,6 +203,7 @@ export const quizSessionManager = {
       userId,
       deckId,
       questionCount = DEFAULT_QUESTION_COUNT,
+      aiJudge = false,
       onTimeout,
     } = options;
 
@@ -133,9 +222,14 @@ export const quizSessionManager = {
       questionNumber: 1,
       totalQuestions: questionCount,
       scores: new Map(),
+      streaks: new Map(),
+      bestStreaks: new Map(),
       answered: false,
+      aiJudge,
       startedBy: userId,
       startedAt: new Date(),
+      attemptedThisQuestion: new Set(),
+      pendingJudgements: new Set(),
       onTimeout: onTimeout ? () => onTimeout(session) : undefined,
     };
 
@@ -169,9 +263,25 @@ export const quizSessionManager = {
   },
 
   /**
-   * Check an answer from a user
+   * Record that a user attempted an answer (regardless of correctness).
+   * Used so streaks can be reset for everyone who missed once the question ends.
    */
-  checkAnswer(channelId: string, oderId: string, answer: string): AnswerResult | null {
+  recordAttempt(channelId: string, userId: string): void {
+    const session = activeSessions.get(channelId);
+    if (!session || session.answered) return;
+    session.attemptedThisQuestion.add(userId);
+  },
+
+  /**
+   * Check an answer from a user using fast string matching.
+   * Returns an AnswerResult if correct, "maybe" if not matched but AI judge is
+   * enabled and the message looks like an answer attempt, or null otherwise.
+   */
+  checkAnswer(
+    channelId: string,
+    userId: string,
+    answer: string
+  ): AnswerResult | 'maybe' | null {
     const session = activeSessions.get(channelId);
 
     if (!session || !session.currentCard || session.answered) {
@@ -180,37 +290,101 @@ export const quizSessionManager = {
 
     const correct = isCorrectAnswer(answer, session.currentCard.back);
 
-    if (!correct) {
-      return null; // Don't return anything for wrong answers
+    if (correct) {
+      return this.awardCorrect(session, userId, false);
     }
 
-    // First correct answer!
+    // String match failed. Signal that the LLM judge should weigh in if
+    // enabled and the message looks like a genuine answer attempt.
+    if (session.aiJudge && looksLikeAnswerAttempt(answer)) {
+      session.attemptedThisQuestion.add(userId);
+      return 'maybe';
+    }
+
+    return null;
+  },
+
+  /**
+   * Ask the LLM to grade an answer that failed the string check. Safe to call
+   * concurrently — only the first verified answer wins the question.
+   */
+  async checkAnswerWithAI(
+    channelId: string,
+    userId: string,
+    answer: string
+  ): Promise<AnswerResult | null> {
+    const session = activeSessions.get(channelId);
+    if (!session || !session.currentCard || session.answered || !session.aiJudge) {
+      return null;
+    }
+
+    const judgementKey = `${session.questionNumber}:${userId}:${answer}`;
+    if (session.pendingJudgements.has(judgementKey)) {
+      return null;
+    }
+    session.pendingJudgements.add(judgementKey);
+
+    const card = session.currentCard;
+    const verdict = await verifyAnswerWithLLM(card.front, card.back, answer);
+
+    // Re-fetch — the session may have ended while we awaited the LLM.
+    const fresh = activeSessions.get(channelId);
+    if (!fresh || fresh !== session || fresh.answered || fresh.currentCard !== card) {
+      return null;
+    }
+
+    if (verdict !== true) {
+      return null;
+    }
+
+    return this.awardCorrect(session, userId, true);
+  },
+
+  /**
+   * Award a correct answer to a user and update scores/streaks.
+   * Internal — callers should go through checkAnswer / checkAnswerWithAI.
+   */
+  awardCorrect(session: QuizSession, userId: string, judgedByAI: boolean): AnswerResult {
     session.answered = true;
 
-    // Clear timeout
     if (session.questionTimeout) {
       clearTimeout(session.questionTimeout);
       session.questionTimeout = undefined;
     }
 
-    // Award point
-    const currentScore = session.scores.get(oderId) || 0;
-    session.scores.set(oderId, currentScore + 1);
+    const currentScore = session.scores.get(userId) || 0;
+    session.scores.set(userId, currentScore + 1);
+
+    // Bump the winner's streak; reset everyone else who attempted this question.
+    const winnerStreak = (session.streaks.get(userId) || 0) + 1;
+    session.streaks.set(userId, winnerStreak);
+    const winnerBest = Math.max(session.bestStreaks.get(userId) || 0, winnerStreak);
+    session.bestStreaks.set(userId, winnerBest);
+
+    for (const attemptedId of session.attemptedThisQuestion) {
+      if (attemptedId !== userId) {
+        session.streaks.set(attemptedId, 0);
+      }
+    }
 
     const quizEnded = session.questionNumber >= session.totalQuestions;
 
     logger.info(
-      `✅ Quiz answer correct! Channel: ${channelId}, User: ${oderId}, Q${session.questionNumber}/${session.totalQuestions}`
+      `✅ Quiz answer correct${judgedByAI ? ' (AI judged)' : ''}! Channel: ${session.channelId}, User: ${userId}, Streak: ${winnerStreak}, Q${session.questionNumber}/${session.totalQuestions}`
     );
 
     return {
       correct: true,
       isFirstCorrect: true,
-      correctAnswer: session.currentCard.back,
+      correctAnswer: session.currentCard!.back,
       currentScores: new Map(session.scores),
+      currentStreaks: new Map(session.streaks),
+      bestStreaks: new Map(session.bestStreaks),
+      winnerStreak,
       questionNumber: session.questionNumber,
       totalQuestions: session.totalQuestions,
       quizEnded,
+      judgedByAI,
     };
   },
 
@@ -236,6 +410,8 @@ export const quizSessionManager = {
     session.currentCard = nextCard;
     session.questionNumber++;
     session.answered = false;
+    session.attemptedThisQuestion = new Set();
+    session.pendingJudgements = new Set();
 
     // Set new timeout
     if (session.onTimeout) {
@@ -274,6 +450,10 @@ export const quizSessionManager = {
     }
 
     session.answered = true;
+    // Skipping = nobody got it. Reset streaks for anyone who attempted.
+    for (const attemptedId of session.attemptedThisQuestion) {
+      session.streaks.set(attemptedId, 0);
+    }
 
     // Move to next question or end
     const nextSession = await this.nextQuestion(channelId);
@@ -295,6 +475,10 @@ export const quizSessionManager = {
 
     const answer = session.currentCard.back;
     session.answered = true;
+    // Timeout = nobody got it. Reset streaks for anyone who attempted.
+    for (const attemptedId of session.attemptedThisQuestion) {
+      session.streaks.set(attemptedId, 0);
+    }
 
     // Move to next question
     const nextSession = await this.nextQuestion(channelId);
@@ -338,7 +522,11 @@ export const quizSessionManager = {
   /**
    * Format scores for display
    */
-  formatScores(scores: Map<string, number>, userMentions?: Map<string, string>): string {
+  formatScores(
+    scores: Map<string, number>,
+    userMentions?: Map<string, string>,
+    streaks?: Map<string, number>
+  ): string {
     if (scores.size === 0) {
       return 'No scores yet!';
     }
@@ -346,12 +534,23 @@ export const quizSessionManager = {
     const sorted = [...scores.entries()].sort((a, b) => b[1] - a[1]);
 
     return sorted
-      .map(([oderId, score], i) => {
+      .map(([userId, score], i) => {
         const medal = i === 0 ? '🥇' : i === 1 ? '🥈' : i === 2 ? '🥉' : '  ';
-        const name = userMentions?.get(oderId) || `<@${oderId}>`;
-        return `${medal} ${name}: ${score}`;
+        const name = userMentions?.get(userId) || `<@${userId}>`;
+        const streak = streaks?.get(userId) || 0;
+        const streakBadge = streak >= 2 ? ` 🔥${streak}` : '';
+        return `${medal} ${name}: ${score}${streakBadge}`;
       })
       .join(' | ');
+  },
+
+  /**
+   * Format a single user's streak as a badge, e.g. " 🔥3" or "" when below threshold.
+   */
+  formatStreakBadge(streak: number): string {
+    if (streak >= 5) return ` 🔥🔥${streak} streak!`;
+    if (streak >= 2) return ` 🔥${streak} streak`;
+    return '';
   },
 
   /**
@@ -363,6 +562,17 @@ export const quizSessionManager = {
     const maxScore = Math.max(...scores.values());
     return [...scores.entries()]
       .filter(([, score]) => score === maxScore)
-      .map(([oderId]) => oderId);
+      .map(([userId]) => userId);
+  },
+
+  /**
+   * Return best streaks (current session) sorted descending. Useful for the
+   * end-of-quiz recap so the "streak champion" can be celebrated alongside
+   * the points winner.
+   */
+  getStreakLeaders(bestStreaks: Map<string, number>): Array<[string, number]> {
+    return [...bestStreaks.entries()]
+      .filter(([, streak]) => streak >= 2)
+      .sort((a, b) => b[1] - a[1]);
   },
 };

--- a/packages/discord/tests/daily-quiz.test.ts
+++ b/packages/discord/tests/daily-quiz.test.ts
@@ -9,9 +9,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getSyncDb } from '@coachartie/shared';
 import {
   DAILY_QUESTION_COUNT,
+  computeDayStreaks,
   ensureDailyQuizTables,
   getDailyLeaderboard,
   getOrCreateDailyPuzzle,
+  getServerLeaderboard,
   getUserPlay,
   markCompleted,
   markShared,
@@ -26,6 +28,7 @@ import {
   buildDailyResultMessage,
   buildDailyShareMessage,
   buildGuessModal,
+  buildLeaderboardMessage,
   dailyCustomId,
   parseDailyCustomId,
 } from '../src/services/daily-quiz-embed';
@@ -227,6 +230,148 @@ describe('leaderboard', () => {
     expect(board.map((r) => r.userId)).toEqual(['bob', 'alice']);
     expect(board[0].score).toBe(5);
     expect(board[1].score).toBe(3);
+  });
+});
+
+describe('computeDayStreaks', () => {
+  it('returns zeros for an empty list', () => {
+    expect(computeDayStreaks([], '2026-05-19')).toEqual({ currentStreak: 0, bestStreak: 0 });
+  });
+
+  it('counts a run of consecutive days ending today', () => {
+    const dates = ['2026-05-17', '2026-05-18', '2026-05-19'];
+    expect(computeDayStreaks(dates, '2026-05-19')).toEqual({
+      currentStreak: 3,
+      bestStreak: 3,
+    });
+  });
+
+  it('treats yesterday as still-streaking (today not yet played)', () => {
+    const dates = ['2026-05-17', '2026-05-18'];
+    expect(computeDayStreaks(dates, '2026-05-19')).toEqual({
+      currentStreak: 2,
+      bestStreak: 2,
+    });
+  });
+
+  it('resets current streak when the most recent play is too old', () => {
+    const dates = ['2026-05-10', '2026-05-11'];
+    expect(computeDayStreaks(dates, '2026-05-19')).toEqual({
+      currentStreak: 0,
+      bestStreak: 2,
+    });
+  });
+
+  it('tracks best streak separately from current', () => {
+    // Played a 4-day streak in May, broke it, played a 1-day "streak" today.
+    const dates = ['2026-05-01', '2026-05-02', '2026-05-03', '2026-05-04', '2026-05-19'];
+    expect(computeDayStreaks(dates, '2026-05-19')).toEqual({
+      currentStreak: 1,
+      bestStreak: 4,
+    });
+  });
+});
+
+describe('getServerLeaderboard', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  function completeRun(
+    userId: string,
+    username: string,
+    guildId: string,
+    date: string,
+    deck: string,
+    correctCount: number
+  ) {
+    startUserPlay(userId, username, date, deck, guildId);
+    for (let i = 0; i < DAILY_QUESTION_COUNT; i++) {
+      recordGuess(userId, date, deck, 'x', i < correctCount);
+    }
+    markCompleted(userId, date, deck);
+  }
+
+  it('ranks users by total correct, then perfect days, then plays', () => {
+    completeRun('alice', 'Alice', 'g1', '2026-05-17', 'POLITICS', 3);
+    completeRun('alice', 'Alice', 'g1', '2026-05-18', 'POLITICS', 5);
+    completeRun('bob', 'Bob', 'g1', '2026-05-18', 'POLITICS', 4);
+    completeRun('cara', 'Cara', 'g1', '2026-05-18', 'POLITICS', 5);
+
+    const board = getServerLeaderboard('g1', 'alltime');
+    expect(board.map((r) => r.userId)).toEqual(['alice', 'cara', 'bob']);
+    expect(board[0].totalCorrect).toBe(8);
+    expect(board[0].perfectDays).toBe(1);
+    expect(board[1].totalCorrect).toBe(5);
+    expect(board[1].perfectDays).toBe(1);
+    expect(board[2].totalCorrect).toBe(4);
+  });
+
+  it('scopes "today" to only today\'s completed plays', () => {
+    const today = todayKey();
+    completeRun('alice', 'Alice', 'g1', '2026-05-01', '', 5);
+    completeRun('bob', 'Bob', 'g1', today, '', 3);
+    const board = getServerLeaderboard('g1', 'today');
+    expect(board.map((r) => r.userId)).toEqual(['bob']);
+  });
+
+  it('excludes plays from other guilds', () => {
+    completeRun('alice', 'Alice', 'g1', '2026-05-18', '', 5);
+    completeRun('eve', 'Eve', 'g2', '2026-05-18', '', 5);
+    const board = getServerLeaderboard('g1', 'alltime');
+    expect(board.map((r) => r.userId)).toEqual(['alice']);
+  });
+
+  it('reports current streak using consecutive completed days', () => {
+    completeRun('alice', 'Alice', 'g1', '2026-05-17', '', 3);
+    completeRun('alice', 'Alice', 'g1', '2026-05-18', '', 3);
+    completeRun('alice', 'Alice', 'g1', '2026-05-19', '', 3);
+    const board = getServerLeaderboard('g1', 'alltime');
+    // The function uses the real "today" for streak reckoning, but as long as
+    // best streak captures the historical run we're good.
+    expect(board[0].bestStreak).toBe(3);
+  });
+});
+
+describe('buildLeaderboardMessage', () => {
+  it('renders the empty-state when no rows', () => {
+    const { embeds } = buildLeaderboardMessage([], 'alltime', 'Room 302');
+    const embed = embeds[0].toJSON();
+    expect(embed.description).toContain('No completed daily quizzes yet');
+  });
+
+  it('renders medal positions and metric badges', () => {
+    const { embeds } = buildLeaderboardMessage(
+      [
+        {
+          userId: 'alice',
+          username: 'Alice',
+          plays: 5,
+          totalCorrect: 22,
+          perfectDays: 2,
+          currentStreak: 3,
+          bestStreak: 4,
+        },
+        {
+          userId: 'bob',
+          username: 'Bob',
+          plays: 3,
+          totalCorrect: 10,
+          perfectDays: 0,
+          currentStreak: 1,
+          bestStreak: 1,
+        },
+      ],
+      'week',
+      'Room 302'
+    );
+    const embed = embeds[0].toJSON();
+    expect(embed.title).toContain('Room 302');
+    expect(embed.description).toMatch(/🥇 <@alice>/);
+    expect(embed.description).toMatch(/⭐2/);
+    expect(embed.description).toMatch(/🔥3/);
+    expect(embed.description).toMatch(/🥈 <@bob>/);
+    expect(embed.footer?.text).toContain('This Week');
   });
 });
 

--- a/packages/discord/tests/daily-quiz.test.ts
+++ b/packages/discord/tests/daily-quiz.test.ts
@@ -12,25 +12,36 @@ import {
   computeDayStreaks,
   ensureDailyQuizTables,
   getDailyLeaderboard,
+  getGuildConfig,
   getOrCreateDailyPuzzle,
   getServerLeaderboard,
   getUserPlay,
+  isDeckAllowedForGuild,
   markCompleted,
   markShared,
   recordGuess,
   renderEmojiGrid,
+  scheduleDailyPuzzle,
+  setGuildAllowedDecks,
+  setGuildDefaultDeck,
   startUserPlay,
   todayKey,
+  tomorrowKey,
   type DailyOutcome,
 } from '../src/services/daily-quiz';
+import type { FlashcardResponse } from '../src/services/quiz-session-manager';
 import {
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
   buildGuessModal,
+  buildGuildConfigEmbed,
   buildLeaderboardMessage,
+  buildScheduleDraftMessage,
   dailyCustomId,
   parseDailyCustomId,
+  parseScheduleCustomId,
+  scheduleCustomId,
 } from '../src/services/daily-quiz-embed';
 
 function clearDailyTables() {
@@ -38,6 +49,19 @@ function clearDailyTables() {
   const db = getSyncDb();
   db.exec('DELETE FROM daily_quiz_plays');
   db.exec('DELETE FROM daily_quiz_puzzles');
+  db.exec('DELETE FROM daily_quiz_guild_config');
+}
+
+function fakeCard(id: string, front: string, back: string): FlashcardResponse {
+  return {
+    id,
+    front,
+    back,
+    hints: [],
+    deckId: 'TEST',
+    deckName: 'Test',
+    course: 'test',
+  };
 }
 
 function mockFlashcards(cards: { id: string; front: string; back: string }[]) {
@@ -464,5 +488,168 @@ describe('embed builders', () => {
     expect(modal.title).toContain('Question 3');
     const row = modal.components[0] as any;
     expect(row.components[0].custom_id).toBe('answer');
+  });
+});
+
+describe('guild config', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  it('returns sane defaults when no config row exists', () => {
+    const cfg = getGuildConfig('g1');
+    expect(cfg).toEqual({ guildId: 'g1', allowedDecks: [], defaultDeck: null });
+  });
+
+  it('persists allowed-decks and dedupes / normalizes input', () => {
+    const cfg = setGuildAllowedDecks('g1', ['POLITICS', 'POLITICS', 'COMPUTERS']);
+    expect(cfg.allowedDecks).toEqual(['POLITICS', 'COMPUTERS']);
+    const reread = getGuildConfig('g1');
+    expect(reread.allowedDecks).toEqual(['POLITICS', 'COMPUTERS']);
+  });
+
+  it('drops unknown decks from the allow-list', () => {
+    const cfg = setGuildAllowedDecks('g1', ['POLITICS', 'NOT_A_DECK']);
+    expect(cfg.allowedDecks).toEqual(['POLITICS']);
+  });
+
+  it('setGuildDefaultDeck stores and clears the default', () => {
+    setGuildDefaultDeck('g1', 'POLITICS');
+    expect(getGuildConfig('g1').defaultDeck).toBe('POLITICS');
+    setGuildDefaultDeck('g1', null);
+    expect(getGuildConfig('g1').defaultDeck).toBeNull();
+  });
+
+  it('isDeckAllowedForGuild defaults to open (no config = anything)', () => {
+    expect(isDeckAllowedForGuild('g1', 'POLITICS')).toBe(true);
+    expect(isDeckAllowedForGuild('g1', '')).toBe(true);
+  });
+
+  it('isDeckAllowedForGuild enforces the allow-list when set', () => {
+    setGuildAllowedDecks('g1', ['POLITICS']);
+    expect(isDeckAllowedForGuild('g1', 'POLITICS')).toBe(true);
+    expect(isDeckAllowedForGuild('g1', 'COMPUTERS')).toBe(false);
+  });
+
+  it('renders config embed with allow-list and default deck', () => {
+    setGuildAllowedDecks('g1', ['POLITICS', 'COMPUTERS']);
+    setGuildDefaultDeck('g1', 'POLITICS');
+    const cfg = getGuildConfig('g1');
+    const embed = buildGuildConfigEmbed(cfg, 'Test Server').embeds[0].toJSON();
+    expect(embed.title).toContain('Test Server');
+    const allowedField = embed.fields?.find((f) => f.name === 'Allowed Decks');
+    expect(allowedField?.value).toContain('POLITICS');
+    expect(allowedField?.value).toContain('COMPUTERS');
+    const defaultField = embed.fields?.find((f) => f.name === 'Default Deck');
+    expect(defaultField?.value).toBe('POLITICS');
+  });
+});
+
+describe('admin scheduling', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  it('scheduleDailyPuzzle inserts a per-guild puzzle for tomorrow', () => {
+    const date = tomorrowKey();
+    const cards = [
+      fakeCard('1', 'q1', 'a1'),
+      fakeCard('2', 'q2', 'a2'),
+      fakeCard('3', 'q3', 'a3'),
+      fakeCard('4', 'q4', 'a4'),
+      fakeCard('5', 'q5', 'a5'),
+    ];
+
+    scheduleDailyPuzzle(date, 'POLITICS', 'g1', cards, 'admin-1');
+
+    // No API calls should happen — we should read the scheduled rows.
+    global.fetch = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+
+    const puzzle = (async () =>
+      await getOrCreateDailyPuzzle(date, 'POLITICS', 'g1'))();
+    return puzzle.then((p) => {
+      expect(p?.cards.map((c) => c.id)).toEqual(['1', '2', '3', '4', '5']);
+    });
+  });
+
+  it('replaces an existing scheduled puzzle on second call (upsert)', () => {
+    const date = tomorrowKey();
+    scheduleDailyPuzzle(
+      date,
+      'POLITICS',
+      'g1',
+      [fakeCard('a', 'qa', 'aa')],
+      'admin-1'
+    );
+    scheduleDailyPuzzle(
+      date,
+      'POLITICS',
+      'g1',
+      [fakeCard('b', 'qb', 'ab')],
+      'admin-2'
+    );
+
+    global.fetch = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+
+    return getOrCreateDailyPuzzle(date, 'POLITICS', 'g1').then((p) => {
+      expect(p?.cards.map((c) => c.id)).toEqual(['b']);
+    });
+  });
+
+  it('isolates scheduled puzzles between guilds', async () => {
+    const date = tomorrowKey();
+    scheduleDailyPuzzle(date, '', 'g1', [fakeCard('g1c', 'q', 'a')], 'admin-1');
+    scheduleDailyPuzzle(date, '', 'g2', [fakeCard('g2c', 'q', 'a')], 'admin-2');
+
+    global.fetch = vi.fn(async () => {
+      throw new Error('fetch should not be called');
+    }) as unknown as typeof fetch;
+
+    const a = await getOrCreateDailyPuzzle(date, '', 'g1');
+    const b = await getOrCreateDailyPuzzle(date, '', 'g2');
+    expect(a?.cards[0].id).toBe('g1c');
+    expect(b?.cards[0].id).toBe('g2c');
+  });
+
+  it('schedule customId round-trips', () => {
+    const id = scheduleCustomId('save', '2026-05-20', 'POLITICS');
+    expect(id).toBe('quiz:schedule:save:2026-05-20:POLITICS');
+    expect(parseScheduleCustomId(id)).toEqual({
+      action: 'save',
+      date: '2026-05-20',
+      deck: 'POLITICS',
+    });
+    expect(parseScheduleCustomId('quiz:daily:guess:x:y')).toBeNull();
+  });
+
+  it('schedule draft preview shows shuffle/save/cancel buttons', () => {
+    const { components } = buildScheduleDraftMessage('2026-05-20', 'POLITICS', [
+      fakeCard('1', 'q', 'a'),
+    ]);
+    const ids = components[0].toJSON().components.map((c: any) => c.custom_id);
+    expect(ids).toEqual([
+      'quiz:schedule:shuffle:2026-05-20:POLITICS',
+      'quiz:schedule:save:2026-05-20:POLITICS',
+      'quiz:schedule:cancel:2026-05-20:POLITICS',
+    ]);
+  });
+
+  it('schedule draft after save strips action buttons', () => {
+    const { components } = buildScheduleDraftMessage(
+      '2026-05-20',
+      'POLITICS',
+      [fakeCard('1', 'q', 'a')],
+      { saved: true }
+    );
+    expect(components).toHaveLength(0);
+  });
+
+  it('tomorrowKey returns the day after today (UTC)', () => {
+    expect(tomorrowKey(new Date('2026-05-19T12:00:00Z'))).toBe('2026-05-20');
+    expect(tomorrowKey(new Date('2026-12-31T12:00:00Z'))).toBe('2027-01-01');
   });
 });

--- a/packages/discord/tests/daily-quiz.test.ts
+++ b/packages/discord/tests/daily-quiz.test.ts
@@ -8,17 +8,22 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getSyncDb } from '@coachartie/shared';
 import {
+  ACHIEVEMENTS,
   DAILY_QUESTION_COUNT,
   attachPollMessage,
   castDeckVote,
   closeDeckPoll,
+  computeAchievements,
   computeDayStreaks,
+  computeUserStats,
+  diffAchievements,
   ensureDailyQuizTables,
   getDailyLeaderboard,
   getDeckPoll,
   getDeckPollById,
   getDeckVoteTallies,
   getGuildConfig,
+  getMostRecentCompletedPlay,
   getOrCreateDailyPuzzle,
   getOrCreateDeckPoll,
   getServerLeaderboard,
@@ -36,9 +41,12 @@ import {
   todayKey,
   tomorrowKey,
   type DailyOutcome,
+  type UserStats,
 } from '../src/services/daily-quiz';
 import type { FlashcardResponse } from '../src/services/quiz-session-manager';
 import {
+  buildAchievementUnlockMessage,
+  buildChallengeMessage,
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
@@ -46,6 +54,7 @@ import {
   buildGuessModal,
   buildGuildConfigEmbed,
   buildLeaderboardMessage,
+  buildProfileMessage,
   buildScheduleDraftMessage,
   dailyCustomId,
   parseDailyCustomId,
@@ -805,5 +814,170 @@ describe('deck vote', () => {
     const closedPoll = getDeckPollById(poll.id)!;
     const { embeds } = buildDeckVoteMessage(closedPoll, tallies, { winningDeck });
     expect(embeds[0].toJSON().fields?.[0].name).toBe('🤷 No winner');
+  });
+});
+
+describe('user stats + achievements', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  function completedPlay(
+    userId: string,
+    guildId: string,
+    date: string,
+    deck: string,
+    correctCount: number
+  ) {
+    startUserPlay(userId, userId, date, deck, guildId);
+    for (let i = 0; i < DAILY_QUESTION_COUNT; i++) {
+      recordGuess(userId, date, deck, 'x', i < correctCount);
+    }
+    markCompleted(userId, date, deck);
+  }
+
+  it('computeUserStats aggregates points / perfects / plays correctly', () => {
+    completedPlay('alice', 'g1', '2026-05-17', '', 5);
+    completedPlay('alice', 'g1', '2026-05-18', '', 3);
+    completedPlay('alice', 'g1', '2026-05-19', '', 5);
+    const stats = computeUserStats('alice', 'g1');
+    expect(stats.totalPlays).toBe(3);
+    expect(stats.totalCorrect).toBe(13);
+    expect(stats.perfectDays).toBe(2);
+    expect(stats.recentResults).toHaveLength(3);
+    // Recent newest-first
+    expect(stats.recentResults[0].date).toBe('2026-05-19');
+  });
+
+  it('computeUserStats scopes to a guild', () => {
+    // Note: the current schema's UNIQUE(user_id, date, deck) doesn't include
+    // guild_id, so two guilds with the same user + deck + date would collide.
+    // Use different decks to exercise the scoping in a realistic way.
+    completedPlay('alice', 'g1', '2026-05-19', 'POLITICS', 5);
+    completedPlay('alice', 'g2', '2026-05-19', 'COMPUTERS', 4);
+    const g1 = computeUserStats('alice', 'g1');
+    const g2 = computeUserStats('alice', 'g2');
+    expect(g1.totalCorrect).toBe(5);
+    expect(g2.totalCorrect).toBe(4);
+  });
+
+  it('zero-play user has all-zeros stats and no badges', () => {
+    const stats = computeUserStats('ghost', 'g1');
+    expect(stats.totalPlays).toBe(0);
+    expect(computeAchievements(stats).size).toBe(0);
+  });
+
+  it('achievements unlock once their predicate flips true', () => {
+    const empty: UserStats = {
+      userId: 'a',
+      guildId: 'g1',
+      totalPlays: 0,
+      totalCorrect: 0,
+      perfectDays: 0,
+      currentStreak: 0,
+      bestStreak: 0,
+      recentResults: [],
+    };
+    expect(computeAchievements(empty).size).toBe(0);
+
+    const oneDay: UserStats = { ...empty, totalPlays: 1, totalCorrect: 5, perfectDays: 1, bestStreak: 1, currentStreak: 1 };
+    const got = computeAchievements(oneDay);
+    expect(got.has('first_blood')).toBe(true);
+    expect(got.has('perfect_1')).toBe(true);
+    expect(got.has('streak_3')).toBe(false);
+  });
+
+  it('diffAchievements returns only newly-unlocked badges', () => {
+    const before: UserStats = {
+      userId: 'a', guildId: 'g1', totalPlays: 2, totalCorrect: 9, perfectDays: 1,
+      currentStreak: 2, bestStreak: 2, recentResults: [],
+    };
+    const after: UserStats = { ...before, totalPlays: 3, totalCorrect: 14, perfectDays: 2, currentStreak: 3, bestStreak: 3 };
+    const newly = diffAchievements(before, after);
+    const ids = newly.map((a) => a.id);
+    expect(ids).toContain('streak_3');
+    expect(ids).not.toContain('first_blood'); // already had
+    expect(ids).not.toContain('perfect_1'); // already had
+  });
+
+  it('getMostRecentCompletedPlay returns the latest completed play in scope', () => {
+    completedPlay('alice', 'g1', '2026-05-17', 'POLITICS', 3);
+    completedPlay('alice', 'g1', '2026-05-19', 'COMPUTERS', 5);
+    const recent = getMostRecentCompletedPlay('alice', 'g1');
+    expect(recent?.date).toBe('2026-05-19');
+    expect(recent?.deck).toBe('COMPUTERS');
+  });
+
+  it('profile embed renders headline metrics and last-7 grid', () => {
+    completedPlay('alice', 'g1', '2026-05-17', '', 5);
+    completedPlay('alice', 'g1', '2026-05-18', '', 3);
+    const stats = computeUserStats('alice', 'g1');
+    const earned = ACHIEVEMENTS.filter((a) => computeAchievements(stats).has(a.id));
+    const { embeds } = buildProfileMessage({ id: 'alice', username: 'Alice' }, stats, earned);
+    const embed = embeds[0].toJSON();
+    expect(embed.title).toContain('Alice');
+    // fields contain Current Streak, Best Streak, Perfect Days, Days Played, Last 7 Days, Badges
+    const names = embed.fields?.map((f) => f.name);
+    expect(names).toEqual(
+      expect.arrayContaining(['Current Streak', 'Best Streak', 'Perfect Days', 'Days Played', 'Last 7 Days', 'Badges'])
+    );
+    const last7 = embed.fields?.find((f) => f.name === 'Last 7 Days');
+    expect(last7?.value).toMatch(/🟩|🟨|🟥/);
+  });
+
+  it('challenge embed mentions target + shows caller\'s score grid', () => {
+    completedPlay('alice', 'g1', todayKey(), '', 4);
+    const recent = getMostRecentCompletedPlay('alice', 'g1');
+    const { content, embeds } = buildChallengeMessage(
+      { id: 'alice', username: 'Alice' },
+      { id: 'bob' },
+      recent,
+      todayKey(),
+      'good luck'
+    );
+    expect(content).toContain('<@bob>');
+    expect(content).toContain('<@alice>');
+    const embed = embeds[0].toJSON();
+    expect(embed.description).toContain(`4/${DAILY_QUESTION_COUNT}`);
+    expect(embed.description).toContain('good luck');
+  });
+
+  it('challenge embed degrades gracefully when caller has no recent play', () => {
+    const { content, embeds } = buildChallengeMessage(
+      { id: 'alice', username: 'Alice' },
+      { id: 'bob' },
+      null,
+      todayKey()
+    );
+    expect(content).toContain('<@bob>');
+    expect(embeds[0].toJSON().description).toContain('/quiz daily');
+  });
+
+  it('achievement-unlock message tags the user and lists badges', () => {
+    const { content, embeds } = buildAchievementUnlockMessage(
+      { id: 'alice', username: 'Alice' },
+      [ACHIEVEMENTS[0], ACHIEVEMENTS[2]]
+    );
+    expect(content).toBe('<@alice>');
+    const embed = embeds[0].toJSON();
+    expect(embed.title).toContain('Achievements unlocked');
+    expect(embed.description).toContain(ACHIEVEMENTS[0].label);
+    expect(embed.description).toContain(ACHIEVEMENTS[2].label);
+  });
+
+  it('achievement-unlock message uses singular header for one badge', () => {
+    const { embeds } = buildAchievementUnlockMessage(
+      { id: 'alice', username: 'Alice' },
+      [ACHIEVEMENTS[0]]
+    );
+    expect(embeds[0].toJSON().title).toContain('Achievement unlocked');
+  });
+
+  it('achievement-unlock message is empty when no badges unlocked', () => {
+    const out = buildAchievementUnlockMessage(
+      { id: 'alice', username: 'Alice' },
+      []
+    );
+    expect(out.embeds).toHaveLength(0);
   });
 });

--- a/packages/discord/tests/daily-quiz.test.ts
+++ b/packages/discord/tests/daily-quiz.test.ts
@@ -9,16 +9,24 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { getSyncDb } from '@coachartie/shared';
 import {
   DAILY_QUESTION_COUNT,
+  attachPollMessage,
+  castDeckVote,
+  closeDeckPoll,
   computeDayStreaks,
   ensureDailyQuizTables,
   getDailyLeaderboard,
+  getDeckPoll,
+  getDeckPollById,
+  getDeckVoteTallies,
   getGuildConfig,
   getOrCreateDailyPuzzle,
+  getOrCreateDeckPoll,
   getServerLeaderboard,
   getUserPlay,
   isDeckAllowedForGuild,
   markCompleted,
   markShared,
+  pickWinningDeck,
   recordGuess,
   renderEmojiGrid,
   scheduleDailyPuzzle,
@@ -34,6 +42,7 @@ import {
   buildDailyGameMessage,
   buildDailyResultMessage,
   buildDailyShareMessage,
+  buildDeckVoteMessage,
   buildGuessModal,
   buildGuildConfigEmbed,
   buildLeaderboardMessage,
@@ -41,7 +50,9 @@ import {
   dailyCustomId,
   parseDailyCustomId,
   parseScheduleCustomId,
+  parseVoteCustomId,
   scheduleCustomId,
+  voteCustomId,
 } from '../src/services/daily-quiz-embed';
 
 function clearDailyTables() {
@@ -50,6 +61,8 @@ function clearDailyTables() {
   db.exec('DELETE FROM daily_quiz_plays');
   db.exec('DELETE FROM daily_quiz_puzzles');
   db.exec('DELETE FROM daily_quiz_guild_config');
+  db.exec('DELETE FROM daily_quiz_deck_votes');
+  db.exec('DELETE FROM daily_quiz_deck_polls');
 }
 
 function fakeCard(id: string, front: string, back: string): FlashcardResponse {
@@ -651,5 +664,146 @@ describe('admin scheduling', () => {
   it('tomorrowKey returns the day after today (UTC)', () => {
     expect(tomorrowKey(new Date('2026-05-19T12:00:00Z'))).toBe('2026-05-20');
     expect(tomorrowKey(new Date('2026-12-31T12:00:00Z'))).toBe('2027-01-01');
+  });
+});
+
+describe('deck vote', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  it('getOrCreateDeckPoll is idempotent on (guild, date)', () => {
+    const a = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    const b = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    expect(b.id).toBe(a.id);
+    expect(b.status).toBe('open');
+  });
+
+  it('castDeckVote records a vote and allows the user to change it', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    castDeckVote(poll.id, 'alice', 'POLITICS');
+    castDeckVote(poll.id, 'bob', 'POLITICS');
+    castDeckVote(poll.id, 'cara', 'COMPUTERS');
+
+    let t = getDeckVoteTallies(poll.id, ['POLITICS', 'COMPUTERS']);
+    expect(t).toEqual([
+      { deck: 'POLITICS', votes: 2 },
+      { deck: 'COMPUTERS', votes: 1 },
+    ]);
+
+    castDeckVote(poll.id, 'alice', 'COMPUTERS'); // change vote
+    t = getDeckVoteTallies(poll.id, ['POLITICS', 'COMPUTERS']);
+    expect(t).toEqual([
+      { deck: 'POLITICS', votes: 1 },
+      { deck: 'COMPUTERS', votes: 2 },
+    ]);
+  });
+
+  it('castDeckVote is a no-op once the poll is closed', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    castDeckVote(poll.id, 'alice', 'POLITICS');
+    closeDeckPoll(poll.id, ['POLITICS']);
+    castDeckVote(poll.id, 'bob', 'POLITICS');
+    const t = getDeckVoteTallies(poll.id, ['POLITICS']);
+    expect(t[0].votes).toBe(1);
+  });
+
+  it('pickWinningDeck picks the highest count with deterministic tie-break', () => {
+    expect(
+      pickWinningDeck([
+        { deck: 'A', votes: 2 },
+        { deck: 'B', votes: 5 },
+        { deck: 'C', votes: 5 },
+      ])
+    ).toBe('B'); // first one matching the max in input order
+    expect(pickWinningDeck([{ deck: 'A', votes: 0 }])).toBeNull();
+  });
+
+  it('closeDeckPoll stamps the winner on the poll row', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    castDeckVote(poll.id, 'a', 'POLITICS');
+    castDeckVote(poll.id, 'b', 'POLITICS');
+    castDeckVote(poll.id, 'c', 'COMPUTERS');
+    const result = closeDeckPoll(poll.id, ['POLITICS', 'COMPUTERS']);
+    expect(result.winningDeck).toBe('POLITICS');
+
+    const reread = getDeckPollById(poll.id);
+    expect(reread?.status).toBe('closed');
+    expect(reread?.winningDeck).toBe('POLITICS');
+    expect(reread?.closedAt).not.toBeNull();
+  });
+
+  it('attachPollMessage stores the public message reference', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    attachPollMessage(poll.id, 'chan-1', 'msg-1');
+    const reread = getDeckPollById(poll.id);
+    expect(reread?.channelId).toBe('chan-1');
+    expect(reread?.messageId).toBe('msg-1');
+  });
+
+  it('voteCustomId round-trips cast + close', () => {
+    expect(parseVoteCustomId(voteCustomId('cast', 7, 'POLITICS'))).toEqual({
+      action: 'cast',
+      pollId: 7,
+      deck: 'POLITICS',
+    });
+    expect(parseVoteCustomId(voteCustomId('close', 7))).toEqual({
+      action: 'close',
+      pollId: 7,
+      deck: '',
+    });
+    expect(parseVoteCustomId('quiz:daily:guess:x:y')).toBeNull();
+    expect(parseVoteCustomId('quiz:vote:cast:not-a-number:POLITICS')).toBeNull();
+  });
+
+  it('voteCustomId encodes the empty-deck sentinel as "all"', () => {
+    expect(voteCustomId('cast', 1, '')).toBe('quiz:vote:cast:1:all');
+    expect(parseVoteCustomId('quiz:vote:cast:1:all')).toEqual({
+      action: 'cast',
+      pollId: 1,
+      deck: '',
+    });
+  });
+
+  it('open-poll embed renders one button per deck + a Close row', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    castDeckVote(poll.id, 'a', 'POLITICS');
+    const tallies = getDeckVoteTallies(poll.id, ['POLITICS', 'COMPUTERS']);
+    const { embeds, components } = buildDeckVoteMessage(poll, tallies);
+    expect(embeds[0].toJSON().description).toContain('POLITICS');
+
+    expect(components).toHaveLength(2);
+    const voteIds = components[0].toJSON().components.map((c: any) => c.custom_id);
+    expect(voteIds).toEqual([
+      `quiz:vote:cast:${poll.id}:POLITICS`,
+      `quiz:vote:cast:${poll.id}:COMPUTERS`,
+    ]);
+    const closeIds = components[1].toJSON().components.map((c: any) => c.custom_id);
+    expect(closeIds).toEqual([`quiz:vote:close:${poll.id}`]);
+  });
+
+  it('closed-poll embed shows the winner and drops the buttons', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    castDeckVote(poll.id, 'a', 'POLITICS');
+    const { winningDeck, tallies } = closeDeckPoll(poll.id, ['POLITICS', 'COMPUTERS']);
+    const closedPoll = getDeckPollById(poll.id)!;
+    const { embeds, components } = buildDeckVoteMessage(closedPoll, tallies, {
+      winningDeck,
+      scheduledOk: true,
+    });
+    expect(components).toHaveLength(0);
+    const embed = embeds[0].toJSON();
+    expect(embed.fields?.[0].name).toBe('🏆 Winner');
+    expect(embed.fields?.[0].value).toContain('POLITICS');
+    expect(embed.fields?.[0].value).toContain('scheduled');
+  });
+
+  it('closed-poll embed handles the no-votes case gracefully', () => {
+    const poll = getOrCreateDeckPoll('g1', '2026-05-20', 'admin');
+    const { winningDeck, tallies } = closeDeckPoll(poll.id, ['POLITICS']);
+    expect(winningDeck).toBeNull();
+    const closedPoll = getDeckPollById(poll.id)!;
+    const { embeds } = buildDeckVoteMessage(closedPoll, tallies, { winningDeck });
+    expect(embeds[0].toJSON().fields?.[0].name).toBe('🤷 No winner');
   });
 });

--- a/packages/discord/tests/daily-quiz.test.ts
+++ b/packages/discord/tests/daily-quiz.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for the async daily quiz — Wordle-style solo play.
+ *
+ * Exercises the puzzle-cache flow, per-user state, emoji grid rendering, the
+ * customId encoding round-trip, and the embed builders.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getSyncDb } from '@coachartie/shared';
+import {
+  DAILY_QUESTION_COUNT,
+  ensureDailyQuizTables,
+  getDailyLeaderboard,
+  getOrCreateDailyPuzzle,
+  getUserPlay,
+  markCompleted,
+  markShared,
+  recordGuess,
+  renderEmojiGrid,
+  startUserPlay,
+  todayKey,
+  type DailyOutcome,
+} from '../src/services/daily-quiz';
+import {
+  buildDailyGameMessage,
+  buildDailyResultMessage,
+  buildDailyShareMessage,
+  buildGuessModal,
+  dailyCustomId,
+  parseDailyCustomId,
+} from '../src/services/daily-quiz-embed';
+
+function clearDailyTables() {
+  ensureDailyQuizTables();
+  const db = getSyncDb();
+  db.exec('DELETE FROM daily_quiz_plays');
+  db.exec('DELETE FROM daily_quiz_puzzles');
+}
+
+function mockFlashcards(cards: { id: string; front: string; back: string }[]) {
+  let i = 0;
+  global.fetch = vi.fn(async () => {
+    const card = cards[i % cards.length];
+    i++;
+    return new Response(
+      JSON.stringify({
+        ...card,
+        hints: [],
+        deckId: 'TEST',
+        deckName: 'Test',
+        course: 'test',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } }
+    );
+  }) as unknown as typeof fetch;
+}
+
+describe('todayKey', () => {
+  it('formats as YYYY-MM-DD in UTC', () => {
+    expect(todayKey(new Date('2026-05-19T23:00:00Z'))).toBe('2026-05-19');
+    expect(todayKey(new Date('2026-01-01T00:00:00Z'))).toBe('2026-01-01');
+  });
+});
+
+describe('renderEmojiGrid', () => {
+  it('pads remaining slots with ⬜', () => {
+    expect(renderEmojiGrid(['correct', 'wrong'] as DailyOutcome[], 5)).toBe(
+      '🟩 🟥 ⬜ ⬜ ⬜'
+    );
+  });
+  it('renders a full row when complete', () => {
+    expect(
+      renderEmojiGrid(['correct', 'correct', 'wrong', 'correct', 'correct'], 5)
+    ).toBe('🟩 🟩 🟥 🟩 🟩');
+  });
+});
+
+describe('customId encoding', () => {
+  it('round-trips guess/modal/share with deck and date', () => {
+    const id = dailyCustomId('guess', '2026-05-19', 'POLITICS');
+    expect(id).toBe('quiz:daily:guess:2026-05-19:POLITICS');
+    expect(parseDailyCustomId(id)).toEqual({
+      action: 'guess',
+      date: '2026-05-19',
+      deck: 'POLITICS',
+    });
+  });
+
+  it('uses "all" sentinel for the empty deck', () => {
+    const id = dailyCustomId('share', '2026-05-19', '');
+    expect(id).toBe('quiz:daily:share:2026-05-19:all');
+    expect(parseDailyCustomId(id)).toEqual({
+      action: 'share',
+      date: '2026-05-19',
+      deck: '',
+    });
+  });
+
+  it('returns null for non-daily custom ids', () => {
+    expect(parseDailyCustomId('quiz:hint')).toBeNull();
+    expect(parseDailyCustomId('ask_123_yes')).toBeNull();
+  });
+});
+
+describe('daily puzzle cache', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches DAILY_QUESTION_COUNT unique cards on first call and caches them', async () => {
+    mockFlashcards([
+      { id: 'a', front: 'Qa', back: 'Aa' },
+      { id: 'b', front: 'Qb', back: 'Ab' },
+      { id: 'c', front: 'Qc', back: 'Ac' },
+      { id: 'd', front: 'Qd', back: 'Ad' },
+      { id: 'e', front: 'Qe', back: 'Ae' },
+    ]);
+
+    const puzzle = await getOrCreateDailyPuzzle('2026-05-19', '');
+    expect(puzzle).not.toBeNull();
+    expect(puzzle!.cards).toHaveLength(DAILY_QUESTION_COUNT);
+    expect((global.fetch as any).mock.calls.length).toBe(5);
+
+    // Second call: served from DB, no extra fetches
+    (global.fetch as any).mockClear();
+    const again = await getOrCreateDailyPuzzle('2026-05-19', '');
+    expect(again!.cards.map((c) => c.id)).toEqual(puzzle!.cards.map((c) => c.id));
+    expect((global.fetch as any).mock.calls.length).toBe(0);
+  });
+
+  it('dedupes by card id when the API hands back collisions', async () => {
+    mockFlashcards([
+      { id: 'a', front: 'Qa', back: 'Aa' },
+      { id: 'a', front: 'Qa', back: 'Aa' }, // dupe
+      { id: 'b', front: 'Qb', back: 'Ab' },
+      { id: 'c', front: 'Qc', back: 'Ac' },
+      { id: 'd', front: 'Qd', back: 'Ad' },
+      { id: 'e', front: 'Qe', back: 'Ae' },
+    ]);
+
+    const puzzle = await getOrCreateDailyPuzzle('2026-05-19', 'POLITICS');
+    expect(puzzle!.cards.map((c) => c.id)).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+});
+
+describe('user play state machine', () => {
+  beforeEach(() => {
+    clearDailyTables();
+    mockFlashcards([
+      { id: 'a', front: 'Qa', back: 'pavlov' },
+      { id: 'b', front: 'Qb', back: 'skinner' },
+      { id: 'c', front: 'Qc', back: 'watson' },
+      { id: 'd', front: 'Qd', back: 'bandura' },
+      { id: 'e', front: 'Qe', back: 'thorndike' },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('startUserPlay is idempotent — second call returns existing state', () => {
+    const a = startUserPlay('alice', 'Alice', '2026-05-19', '');
+    a.results.push('correct'); // local mutation, irrelevant to db
+    const b = startUserPlay('alice', 'Alice', '2026-05-19', '');
+    expect(b.currentQuestion).toBe(0);
+    expect(b.results).toEqual([]);
+  });
+
+  it('recordGuess advances state and stores results', async () => {
+    await getOrCreateDailyPuzzle('2026-05-19', '');
+    startUserPlay('alice', 'Alice', '2026-05-19', '');
+
+    const after1 = recordGuess('alice', '2026-05-19', '', 'pavlov', true);
+    expect(after1?.currentQuestion).toBe(1);
+    expect(after1?.results).toEqual(['correct']);
+
+    const after2 = recordGuess('alice', '2026-05-19', '', 'guesswork', false);
+    expect(after2?.currentQuestion).toBe(2);
+    expect(after2?.results).toEqual(['correct', 'wrong']);
+    expect(after2?.guesses).toEqual(['pavlov', 'guesswork']);
+  });
+
+  it('markCompleted flips the completed flag and timestamps', () => {
+    startUserPlay('alice', 'Alice', '2026-05-19', '');
+    const done = markCompleted('alice', '2026-05-19', '');
+    expect(done?.completed).toBe(true);
+    expect(done?.completedAt).not.toBeNull();
+  });
+
+  it('markShared flips the shared flag', () => {
+    startUserPlay('alice', 'Alice', '2026-05-19', '');
+    markShared('alice', '2026-05-19', '');
+    const play = getUserPlay('alice', '2026-05-19', '');
+    expect(play?.shared).toBe(true);
+  });
+});
+
+describe('leaderboard', () => {
+  beforeEach(() => {
+    clearDailyTables();
+  });
+
+  it('ranks completed plays by score then completion time', () => {
+    startUserPlay('alice', 'Alice', '2026-05-19', 'POLITICS');
+    startUserPlay('bob', 'Bob', '2026-05-19', 'POLITICS');
+    startUserPlay('cara', 'Cara', '2026-05-19', 'POLITICS');
+
+    // Alice 3/5, Bob 5/5, Cara unfinished
+    recordGuess('alice', '2026-05-19', 'POLITICS', 'x', true);
+    recordGuess('alice', '2026-05-19', 'POLITICS', 'x', true);
+    recordGuess('alice', '2026-05-19', 'POLITICS', 'x', true);
+    recordGuess('alice', '2026-05-19', 'POLITICS', 'x', false);
+    recordGuess('alice', '2026-05-19', 'POLITICS', 'x', false);
+    markCompleted('alice', '2026-05-19', 'POLITICS');
+
+    for (let i = 0; i < 5; i++) {
+      recordGuess('bob', '2026-05-19', 'POLITICS', 'x', true);
+    }
+    markCompleted('bob', '2026-05-19', 'POLITICS');
+
+    const board = getDailyLeaderboard('2026-05-19', 'POLITICS');
+    expect(board.map((r) => r.userId)).toEqual(['bob', 'alice']);
+    expect(board[0].score).toBe(5);
+    expect(board[1].score).toBe(3);
+  });
+});
+
+describe('embed builders', () => {
+  beforeEach(() => {
+    clearDailyTables();
+    mockFlashcards([
+      { id: 'a', front: 'Who paired bell with food?', back: 'pavlov' },
+      { id: 'b', front: 'Who studied operant conditioning?', back: 'skinner' },
+      { id: 'c', front: 'Founded behaviorism?', back: 'watson' },
+      { id: 'd', front: 'Bobo doll?', back: 'bandura' },
+      { id: 'e', front: 'Law of effect?', back: 'thorndike' },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('mid-game embed shows the progress grid, current question, and a Guess button', async () => {
+    const puzzle = await getOrCreateDailyPuzzle('2026-05-19', '');
+    const play = startUserPlay('alice', 'Alice', '2026-05-19', '');
+    const { embeds, components } = buildDailyGameMessage(play, puzzle!);
+    const embed = embeds[0].toJSON();
+    expect(embed.description).toContain('⬜ ⬜ ⬜ ⬜ ⬜');
+    expect(embed.fields?.some((f) => f.name.includes('Question 1'))).toBe(true);
+
+    const row = components[0].toJSON();
+    expect(row.components).toHaveLength(1);
+    expect((row.components[0] as any).custom_id).toBe('quiz:daily:guess:2026-05-19:all');
+  });
+
+  it('result embed shows the full answer key and a Share button when not yet shared', async () => {
+    const puzzle = await getOrCreateDailyPuzzle('2026-05-19', '');
+    startUserPlay('alice', 'Alice', '2026-05-19', '');
+    recordGuess('alice', '2026-05-19', '', 'pavlov', true);
+    recordGuess('alice', '2026-05-19', '', 'skinner', true);
+    recordGuess('alice', '2026-05-19', '', 'wrong', false);
+    recordGuess('alice', '2026-05-19', '', 'bandura', true);
+    recordGuess('alice', '2026-05-19', '', 'thorndike', true);
+    const done = markCompleted('alice', '2026-05-19', '');
+
+    const { embeds, components } = buildDailyResultMessage(done!, puzzle!, 'Alice');
+    const embed = embeds[0].toJSON();
+    expect(embed.title).toContain('Daily Quiz');
+    expect(embed.description).toContain('4 / 5');
+    expect(embed.fields?.[0].value).toContain('pavlov');
+
+    const btn = components[0].toJSON().components[0] as any;
+    expect(btn.custom_id).toBe('quiz:daily:share:2026-05-19:all');
+    expect(btn.disabled).toBe(false);
+  });
+
+  it('result embed disables Share once shared', async () => {
+    const puzzle = await getOrCreateDailyPuzzle('2026-05-19', '');
+    startUserPlay('alice', 'Alice', '2026-05-19', '');
+    recordGuess('alice', '2026-05-19', '', 'pavlov', true);
+    markCompleted('alice', '2026-05-19', '');
+    markShared('alice', '2026-05-19', '');
+    const play = getUserPlay('alice', '2026-05-19', '');
+
+    const { components } = buildDailyResultMessage(play!, puzzle!, 'Alice');
+    const btn = components[0].toJSON().components[0] as any;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it('share message contains the emoji grid + score', () => {
+    const play = {
+      userId: 'alice',
+      username: 'Alice',
+      date: '2026-05-19',
+      deck: '',
+      currentQuestion: 5,
+      results: ['correct', 'correct', 'wrong', 'correct', 'correct'] as DailyOutcome[],
+      guesses: ['a', 'b', 'c', 'd', 'e'],
+      completed: true,
+      shared: false,
+      startedAt: '',
+      completedAt: null,
+    };
+    const embed = buildDailyShareMessage(play, 'Alice').embeds[0].toJSON();
+    expect(embed.description).toContain('Alice');
+    expect(embed.description).toContain('4/5');
+    expect(embed.description).toContain('🟩 🟩 🟥 🟩 🟩');
+  });
+
+  it('guess modal has a single short text input', () => {
+    const modal = buildGuessModal('2026-05-19', 'POLITICS', 3).toJSON();
+    expect(modal.custom_id).toBe('quiz:daily:modal:2026-05-19:POLITICS');
+    expect(modal.title).toContain('Question 3');
+    const row = modal.components[0] as any;
+    expect(row.components[0].custom_id).toBe('answer');
+  });
+});

--- a/packages/discord/tests/quiz-embed.test.ts
+++ b/packages/discord/tests/quiz-embed.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the Wordle-style quiz embed/button builders and the supporting
+ * state (progress bar, hint reveal, message-id tracking).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  quizSessionManager,
+  renderProgressBar,
+  buildInitialProgress,
+  type FlashcardResponse,
+} from '../src/services/quiz-session-manager';
+import {
+  buildLiveQuizMessage,
+  buildQuizSummary,
+  quizButtonId,
+  parseQuizButtonId,
+} from '../src/services/quiz-embed';
+
+const CHANNEL = 'test-channel-embed';
+
+function makeCard(front: string, back: string, hints: string[] = [], id = '1'): FlashcardResponse {
+  return {
+    id,
+    front,
+    back,
+    hints,
+    deckId: 'TEST',
+    deckName: 'Test',
+    course: 'test',
+  };
+}
+
+describe('progress bar', () => {
+  it('buildInitialProgress marks the first slot current, rest upcoming', () => {
+    const p = buildInitialProgress(3);
+    expect(p).toEqual(['current', 'upcoming', 'upcoming']);
+  });
+
+  it('renderProgressBar maps outcomes to emoji squares', () => {
+    expect(renderProgressBar(['correct', 'missed', 'current', 'upcoming'])).toBe(
+      '🟩 ⬛ 🟨 ⬜'
+    );
+  });
+});
+
+describe('quizButtonId / parseQuizButtonId', () => {
+  it('round-trips known actions', () => {
+    for (const action of ['hint', 'skip', 'end', 'again'] as const) {
+      expect(parseQuizButtonId(quizButtonId(action))).toBe(action);
+    }
+  });
+
+  it('returns null for non-quiz custom ids', () => {
+    expect(parseQuizButtonId('ask_123_yes')).toBeNull();
+    expect(parseQuizButtonId('quiz:bogus')).toBeNull();
+  });
+});
+
+describe('live quiz embed', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify(makeCard('Define classical conditioning', 'pavlov', ['Russian scientist'])),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    quizSessionManager.endQuiz(CHANNEL);
+    vi.restoreAllMocks();
+  });
+
+  it('renders the current question, progress bar, and an action row with 3 buttons', async () => {
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 3,
+    });
+
+    const { embeds, components } = buildLiveQuizMessage(session);
+    expect(embeds).toHaveLength(1);
+    const embed = embeds[0].toJSON();
+    expect(embed.title).toContain('Quiz');
+    expect(embed.description).toContain('🟨'); // current marker
+    expect(embed.fields?.some((f) => f.name.includes('Question'))).toBe(true);
+    expect(embed.fields?.some((f) => f.name.includes('Scoreboard'))).toBe(true);
+
+    expect(components).toHaveLength(1);
+    const row = components[0].toJSON();
+    expect(row.components).toHaveLength(3);
+    const ids = row.components.map((c: any) => c.custom_id);
+    expect(ids).toEqual(['quiz:hint', 'quiz:skip', 'quiz:end']);
+  });
+
+  it('disables the Hint button when no hints remain', async () => {
+    global.fetch = vi.fn(async () => {
+      return new Response(JSON.stringify(makeCard('No hints?', 'nope', [])), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 1,
+    });
+
+    const row = buildLiveQuizMessage(session).components[0].toJSON();
+    const hintBtn = row.components.find((c: any) => c.custom_id === 'quiz:hint') as any;
+    expect(hintBtn.disabled).toBe(true);
+  });
+
+  it('revealHint appends a hint and decrements the remaining counter', async () => {
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 1,
+    });
+
+    const before = buildLiveQuizMessage(session);
+    const hintBtnBefore = before.components[0].toJSON().components.find(
+      (c: any) => c.custom_id === 'quiz:hint'
+    ) as any;
+    expect(hintBtnBefore.label).toBe('Hint (1)');
+
+    const hint = quizSessionManager.revealHint(CHANNEL);
+    expect(hint).toBe('Russian scientist');
+
+    const after = buildLiveQuizMessage(session);
+    const embed = after.embeds[0].toJSON();
+    expect(embed.fields?.some((f) => f.name.startsWith('💡 Hints'))).toBe(true);
+
+    const hintBtnAfter = after.components[0].toJSON().components.find(
+      (c: any) => c.custom_id === 'quiz:hint'
+    ) as any;
+    // No more hints — button disabled, count gone from label
+    expect(hintBtnAfter.disabled).toBe(true);
+    expect(hintBtnAfter.label).toBe('Hint');
+  });
+
+  it('progress bar advances after correct + nextQuestion', async () => {
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 3,
+    });
+
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'pavlov');
+    expect(session.progress).toEqual(['correct', 'upcoming', 'upcoming']);
+
+    await quizSessionManager.nextQuestion(CHANNEL);
+    expect(session.progress).toEqual(['correct', 'current', 'upcoming']);
+  });
+});
+
+describe('quiz summary card', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => {
+      return new Response(JSON.stringify(makeCard('Q', 'A')), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    quizSessionManager.endQuiz(CHANNEL);
+    vi.restoreAllMocks();
+  });
+
+  it('shows winner, streak champion, and a Play Again button', async () => {
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 2,
+    });
+
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A');
+    await quizSessionManager.nextQuestion(CHANNEL);
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A');
+
+    const summary = buildQuizSummary(session, new Map([['alice', 2]]));
+    const embed = summary.embeds[0].toJSON();
+    expect(embed.title).toContain('Complete');
+    expect(embed.description).toContain('🟩');
+    expect(embed.description).toContain('<@alice>'); // winner mention
+    expect(embed.description).toContain('Streak Champion');
+
+    const row = summary.components[0].toJSON();
+    expect(row.components).toHaveLength(1);
+    expect((row.components[0] as any).custom_id).toBe('quiz:again');
+  });
+
+  it('handles the "nobody scored" case gracefully', async () => {
+    const session = await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'host',
+      questionCount: 1,
+    });
+
+    const summary = buildQuizSummary(session, new Map());
+    const embed = summary.embeds[0].toJSON();
+    expect(embed.description).toContain('No one scored');
+  });
+});

--- a/packages/discord/tests/quiz-session-manager.test.ts
+++ b/packages/discord/tests/quiz-session-manager.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for quiz session manager — streak tracking and AI-judged answers.
+ *
+ * The flashcard fetch is mocked so these tests run offline. The LLM judge is
+ * gated on OPENROUTER_API_KEY; when unset, verifyAnswerWithLLM returns null
+ * and the manager treats AI-judged checks as misses.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  quizSessionManager,
+  looksLikeAnswerAttempt,
+  type FlashcardResponse,
+} from '../src/services/quiz-session-manager';
+
+const CHANNEL = 'test-channel-streaks';
+
+function makeCard(front: string, back: string, id = '1'): FlashcardResponse {
+  return {
+    id,
+    front,
+    back,
+    hints: [],
+    deckId: 'TEST',
+    deckName: 'Test',
+    course: 'test',
+  };
+}
+
+describe('looksLikeAnswerAttempt', () => {
+  it('rejects empty / whitespace', () => {
+    expect(looksLikeAnswerAttempt('')).toBe(false);
+    expect(looksLikeAnswerAttempt('   ')).toBe(false);
+  });
+
+  it('rejects slash and bang commands', () => {
+    expect(looksLikeAnswerAttempt('/quiz stop')).toBe(false);
+    expect(looksLikeAnswerAttempt('!skip')).toBe(false);
+  });
+
+  it('rejects pure emoji / punctuation', () => {
+    expect(looksLikeAnswerAttempt('🔥🔥')).toBe(false);
+    expect(looksLikeAnswerAttempt('!!!')).toBe(false);
+  });
+
+  it('rejects very long messages', () => {
+    expect(looksLikeAnswerAttempt('a'.repeat(201))).toBe(false);
+  });
+
+  it('accepts plausible short answers', () => {
+    expect(looksLikeAnswerAttempt('classical conditioning')).toBe(true);
+    expect(looksLikeAnswerAttempt('Pavlov')).toBe(true);
+  });
+});
+
+describe('quizSessionManager streaks', () => {
+  beforeEach(() => {
+    // Mock the flashcard API so we control the cards
+    let n = 0;
+    global.fetch = vi.fn(async () => {
+      n++;
+      return new Response(JSON.stringify(makeCard(`Q${n}`, `A${n}`, String(n))), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    quizSessionManager.endQuiz(CHANNEL);
+    vi.restoreAllMocks();
+  });
+
+  it('starts at streak 0 and bumps to 1 on correct answer', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+    });
+
+    const result = quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A1');
+    expect(result).not.toBeNull();
+    expect(result).not.toBe('maybe');
+    if (!result || result === 'maybe') return;
+    expect(result.correct).toBe(true);
+    expect(result.winnerStreak).toBe(1);
+    expect(result.currentStreaks.get('alice')).toBe(1);
+    expect(result.bestStreaks.get('alice')).toBe(1);
+  });
+
+  it('builds a streak across consecutive correct answers', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+    });
+
+    const r1 = quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A1');
+    expect(r1 && r1 !== 'maybe' && r1.winnerStreak).toBe(1);
+    await quizSessionManager.nextQuestion(CHANNEL);
+
+    const r2 = quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A2');
+    expect(r2 && r2 !== 'maybe' && r2.winnerStreak).toBe(2);
+    expect(r2 && r2 !== 'maybe' && r2.bestStreaks.get('alice')).toBe(2);
+  });
+
+  it("breaks a user's streak when someone else wins a question they attempted", async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+    });
+
+    // Alice wins Q1
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A1');
+    await quizSessionManager.nextQuestion(CHANNEL);
+
+    // Alice attempts Q2 with a wrong answer; Bob wins it
+    const aliceMiss = quizSessionManager.checkAnswer(CHANNEL, 'alice', 'wrong-guess');
+    expect(aliceMiss).toBeNull();
+    quizSessionManager.recordAttempt(CHANNEL, 'alice');
+
+    const bobWin = quizSessionManager.checkAnswer(CHANNEL, 'bob', 'A2');
+    expect(bobWin && bobWin !== 'maybe' && bobWin.winnerStreak).toBe(1);
+    expect(bobWin && bobWin !== 'maybe' && bobWin.currentStreaks.get('alice')).toBe(0);
+    // But Alice's best in the session is still her earlier 1
+    expect(bobWin && bobWin !== 'maybe' && bobWin.bestStreaks.get('alice')).toBe(1);
+  });
+
+  it('does not break the streak of a user who did not attempt', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+    });
+
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A1');
+    await quizSessionManager.nextQuestion(CHANNEL);
+
+    // Alice doesn't attempt Q2 at all; Bob wins
+    const bobWin = quizSessionManager.checkAnswer(CHANNEL, 'bob', 'A2');
+    expect(bobWin && bobWin !== 'maybe' && bobWin.currentStreaks.get('alice')).toBe(1);
+  });
+
+  it('resets streaks for all attempters on timeout', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+    });
+
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'A1');
+    await quizSessionManager.nextQuestion(CHANNEL);
+
+    // Alice & Bob both miss Q2
+    quizSessionManager.checkAnswer(CHANNEL, 'alice', 'nope');
+    quizSessionManager.recordAttempt(CHANNEL, 'alice');
+    quizSessionManager.recordAttempt(CHANNEL, 'bob');
+
+    await quizSessionManager.handleTimeout(CHANNEL);
+
+    const session = quizSessionManager.getSession(CHANNEL);
+    expect(session?.streaks.get('alice')).toBe(0);
+    expect(session?.streaks.get('bob')).toBe(0);
+    // Alice's best streak from earlier survives
+    expect(session?.bestStreaks.get('alice')).toBe(1);
+  });
+
+  it('returns "maybe" when AI judge is on, string match fails, message looks like an attempt', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+      aiJudge: true,
+    });
+
+    const result = quizSessionManager.checkAnswer(CHANNEL, 'alice', 'completely different');
+    expect(result).toBe('maybe');
+  });
+
+  it('returns null for chatter when AI judge is on', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+      aiJudge: true,
+    });
+
+    expect(quizSessionManager.checkAnswer(CHANNEL, 'alice', '!skip')).toBeNull();
+    expect(quizSessionManager.checkAnswer(CHANNEL, 'alice', '🔥')).toBeNull();
+  });
+
+  it('drops AI verdicts that arrive after the question is already answered', async () => {
+    await quizSessionManager.startQuiz({
+      channelId: CHANNEL,
+      userId: 'starter',
+      questionCount: 3,
+      aiJudge: true,
+    });
+
+    // Force the LLM to say yes, but also have someone else win first
+    process.env.OPENROUTER_API_KEY = 'fake-test-key';
+    global.fetch = vi.fn(async () => {
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: 'yes' } }] }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      );
+    }) as unknown as typeof fetch;
+
+    // Bob wins synchronously
+    const bobWin = quizSessionManager.checkAnswer(CHANNEL, 'bob', 'A1');
+    expect(bobWin && bobWin !== 'maybe').toBeTruthy();
+
+    // Alice's deferred LLM check should now be a no-op
+    const aliceLate = await quizSessionManager.checkAnswerWithAI(
+      CHANNEL,
+      'alice',
+      'something fuzzy'
+    );
+    expect(aliceLate).toBeNull();
+    delete process.env.OPENROUTER_API_KEY;
+  });
+});


### PR DESCRIPTION
## Summary

Picks up the #shenanigans pitch from Drake + Sylvan — "anki bot with behaviorism terms… we could compete getting streaks… we could use a very light LLM on the backend to check if it was right." The existing `/quiz` command already covers the typed-answer flashcard loop with curated decks, so this PR adds the two missing pieces.

- **Per-session streaks** with 🔥 badges, broadcast in score lines and an end-of-quiz "Streak Champion" callout. A user's streak only breaks on a question they *attempted and missed*, so sitting out doesn't penalize you — keeps the "compete for streaks" framing.
- **`ai_judge:true` flag on `/quiz start`** that calls a light LLM (Gemini Flash by default via OpenRouter) when the string check fails, so synonyms / abbreviations / minor wording differences count. Gated by a `looksLikeAnswerAttempt` heuristic so the judge isn't called on chatter / commands / emoji-only messages.
- **🤖 reaction** instead of ✅ when the AI judge was the one who accepted the answer, so it's transparent that an LLM weighed in. Late LLM verdicts are dropped if another user already won the question.
- **13 new unit tests** (`packages/discord/tests/quiz-session-manager.test.ts`) covering streak award/reset, the race where an LLM verdict arrives after the question closed, and the chatter-vs-attempt heuristic.

## Test plan

- [x] `npx vitest run packages/discord/tests/` — 25/25 passing (13 new + 12 existing)
- [x] `tsc --noEmit` on `packages/discord` — no new errors
- [ ] Live smoke in a Discord channel: `/quiz start ai_judge:true questions:3`, intentionally answer with a synonym, confirm 🤖 reaction + streak shows in the next score line
- [ ] Live smoke without `ai_judge`: verify default behavior is unchanged (string matching only, ✅ reaction)
- [ ] Verify `OPENROUTER_API_KEY` env is present on the discord PM2 process before relying on AI judge in prod

## Config

- `QUIZ_JUDGE_MODEL` (default `google/gemini-2.0-flash-001`) — overrideable per env
- `QUIZ_JUDGE_URL` (default `https://router.tools.ejfox.com/v1/chat/completions`) — same router used by the proactive-judgment path
- Reuses the existing `OPENROUTER_API_KEY`; if unset, AI judge silently no-ops (string match only)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDaoVYCqE1dQikQ1Yr1xBX)_